### PR TITLE
fix: downgraded react-native-elements

### DIFF
--- a/packages/ui/core/Form/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/packages/ui/core/Form/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -11,7 +11,6 @@ exports[`Slider renders correctly 1`] = `
   }
 >
   <View
-    allowTouchTrack={false}
     animationType="timing"
     maximum={50}
     minimum={1}
@@ -29,7 +28,6 @@ exports[`Slider renders correctly 1`] = `
     theme={
       Object {
         "colors": Object {
-          "black": "#242424",
           "disabled": "hsl(208, 8%, 90%)",
           "divider": "#bcbbc1",
           "error": "#ff190c",
@@ -43,7 +41,6 @@ exports[`Slider renders correctly 1`] = `
           "platform": Object {
             "android": Object {
               "error": "#f44336",
-              "grey": "rgba(0, 0, 0, 0.54)",
               "primary": "#2196f3",
               "secondary": "#9C27B0",
               "success": "#4caf50",
@@ -51,9 +48,7 @@ exports[`Slider renders correctly 1`] = `
             },
             "ios": Object {
               "error": "#ff3b30",
-              "grey": "#7d7d7d",
               "primary": "#007aff",
-              "searchBg": "#dcdce1",
               "secondary": "#5856d6",
               "success": "#4cd964",
               "warning": "#ffcc00",
@@ -61,10 +56,9 @@ exports[`Slider renders correctly 1`] = `
           },
           "primary": "#2089dc",
           "searchBg": "#303337",
-          "secondary": "#ca71eb",
+          "secondary": "#8F0CE8",
           "success": "#52c41a",
           "warning": "#faad14",
-          "white": "#ffffff",
         },
       }
     }
@@ -91,7 +85,7 @@ exports[`Slider renders correctly 1`] = `
         Object {
           "backgroundColor": "#2ED68F",
           "borderRadius": 4,
-          "height": 0,
+          "height": 5,
           "marginTop": -0,
           "position": "absolute",
           "width": 0,
@@ -108,9 +102,13 @@ exports[`Slider renders correctly 1`] = `
           "borderWidth": 2,
           "height": 14,
           "position": "absolute",
+          "top": 22,
           "transform": Array [
             Object {
               "translateX": 0,
+            },
+            Object {
+              "translateY": -0,
             },
           ],
           "width": 14,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,7 +16,7 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-40.0.0.tar.gz",
-    "react-native-elements": "^2.0.0",
+    "react-native-elements": "2.0.1",
     "react-native-ratings": "^7.2.0",
     "react-native-reanimated": "~1.13.0",
     "react-native-svg": "^11.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3850,7 +3850,7 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react-native-vector-icons@^6.4.5":
+"@types/react-native-vector-icons@^6.4.0":
   version "6.4.6"
   resolved "https://registry.yarnpkg.com/@types/react-native-vector-icons/-/react-native-vector-icons-6.4.6.tgz#848e3b14572def56212cafbf5cb1254b445bfb41"
   integrity sha512-lAyxNfMd5L1xZvXWsGcJmNegDf61TAp40uL6ashNNWj9W3IrDJO59L9+9inh0Y2MsEZpLTdxzVU8Unb4/0FQng==
@@ -7331,7 +7331,7 @@ deep-scope-analyser@^1.6.0:
     esrecurse "^4.2.1"
     estraverse "^4.2.0"
 
-deepmerge@^3.2.0:
+deepmerge@^3.1.0, deepmerge@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.3.0.tgz#d3c47fd6f3a93d517b14426b0628a17b0125f5f7"
   integrity sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==
@@ -15586,20 +15586,20 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-native-elements@^2.0.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/react-native-elements/-/react-native-elements-2.3.2.tgz#f6b974127a3484bb46ebd98fbc012fb2208decd7"
-  integrity sha512-HygYYmq8JYjk/YYiUwr/64qT64H2xlPBz0JnkGTQwvnnyXZrfkHFopw8rLWCupv3iLLPDzVohvPs0Z5HLdonSQ==
+react-native-elements@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-elements/-/react-native-elements-2.0.1.tgz#7c27f3f5b41f8d05a4378d258ff4335a62badf48"
+  integrity sha512-2po0zq+MsR9pGdLGPoZfCm5K+FK88e7OGuXBne7pQG2wtgf391sQbLz37R0qryllcH1QIn9ZXNm1nuL7MRYNQg==
   dependencies:
-    "@types/react-native-vector-icons" "^6.4.5"
+    "@types/react-native-vector-icons" "^6.4.0"
     color "^3.1.0"
-    deepmerge "^4.2.2"
+    deepmerge "^3.1.0"
     hoist-non-react-statics "^3.1.0"
     lodash.isequal "^4.5.0"
     opencollective-postinstall "^2.0.0"
     prop-types "^15.7.2"
     react-native-ratings "^7.2.0"
-    react-native-status-bar-height "^2.5.0"
+    react-native-status-bar-height "^2.2.0"
 
 react-native-gesture-handler@~1.8.0:
   version "1.8.0"
@@ -15641,7 +15641,7 @@ react-native-screens@~2.15.0:
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.15.0.tgz#9b97c1881c4fcdf304bf363f0013225901625f44"
   integrity sha512-qTSQPy0WKHtlb8xt5gY0Gt6sdvfQUQAnFSqgsggW9UEvySbkHzpqOrOYNA79Ca8oXO0dCFwp6X8buIiDefa7+Q==
 
-react-native-status-bar-height@^2.5.0:
+react-native-status-bar-height@^2.2.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/react-native-status-bar-height/-/react-native-status-bar-height-2.6.0.tgz#b6afd25b6e3d533c43d0fcdcfd5cafd775592cea"
   integrity sha512-z3SGLF0mHT+OlJDq7B7h/jXPjWcdBT3V14Le5L2PjntjjWM3+EJzq2BcXDwV+v67KFNJic5pgA26cCmseYek6w==


### PR DESCRIPTION
Downgrading `react-native-elements` and fixing the version in `2.0.1` due to a Yarn warn with the patch applied in `patches/react-native-elements+2.0.1.patch` which cause a failure in GitHub Actions.

`Slider.test.tsx.snap` updated using `$ jest -u`