### PR TITLE
Fix bugs

### DIFF
--- a/packages/expo/metro.config.js
+++ b/packages/expo/metro.config.js
@@ -1,3 +1,28 @@
 const {createMetroConfiguration} = require('expo-yarn-workspaces');
 
-module.exports = createMetroConfiguration(__dirname);
+const config = createMetroConfiguration(__dirname);
+
+config.server = {
+  enhanceMiddleware: middleware => {
+    return (req, res, next) => {
+      const assets = '/ui/assets/';
+      if (req.url.startsWith(assets)) {
+        // At the beginning of the path to your assets should always be "/assets/"
+        // Next exit from the current directory
+        req.url = req.url.replace(assets, '/assets/../ui/assets/');
+      }
+
+      // Fix showing back icon on android
+      // This is necessary if you are working with react-navigation and
+      // it is installed globally for monorepo.
+      const otherAssets = '/node_modules/';
+      if (req.url.startsWith(otherAssets)) {
+        req.url = req.url.replace(otherAssets, '/assets/../../node_modules/');
+      }
+
+      return middleware(req, res, next);
+    };
+  },
+};
+
+module.exports = config;

--- a/packages/expo/src/modules/auth/ContinueWithFacebook.tsx
+++ b/packages/expo/src/modules/auth/ContinueWithFacebook.tsx
@@ -5,6 +5,7 @@ import {useNavigation} from '@react-navigation/native';
 import FacebookProvider, {Login} from 'react-facebook-sdk';
 import {FacebookButton} from '@animavita/ui/social';
 import {graphql, useMutation} from '@animavita/relay';
+import {differenceInSeconds} from 'date-fns';
 
 import getEnvVars from '../../../environment';
 import {changeShowBottomBar} from '../../utils/bottomBar';
@@ -64,7 +65,7 @@ const ContinueWithFacebook: React.FC = () => {
   useEffect(() => {
     async function initializeFacebookSDK() {
       try {
-        await Facebook.initializeAsync(fbAppID, fbAppName);
+        await Facebook.initializeAsync({appId: fbAppID, appName: fbAppName});
       } catch ({message}) {
         // eslint-disable-next-line no-console
         console.log(`Facebook Login Error: ${message}`);
@@ -98,14 +99,15 @@ const ContinueWithFacebook: React.FC = () => {
     });
 
     if (response.type === 'success') {
-      const {token, permissions, expires} = response;
+      const {token, permissions, expirationDate} = response;
+      const expires = differenceInSeconds(new Date(expirationDate), new Date());
 
       saveFacebookUser({
         variables: {
           input: {
             token,
             expires,
-            permissions,
+            permissions: permissions || [],
           },
         },
         onCompleted,

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -22,7 +22,6 @@
     "graphql": "^14.6.0",
     "graphql-playground-middleware": "^1.1.2",
     "graphql-relay": "^0.6.0",
-    "image-to-base64": "^2.0.1",
     "isomorphic-fetch": "^2.2.1",
     "jsonwebtoken": "^8.5.1",
     "koa": "^2.11.0",
@@ -31,7 +30,8 @@
     "koa-cors": "^0.0.16",
     "koa-graphql": "^0.8.0",
     "koa-logger": "^3.2.1",
-    "mongoose": "^5.8.11"
+    "mongoose": "^5.8.11",
+    "node-base64-image": "^2.0.1"
   },
   "devDependencies": {
     "@types/aws-sdk": "^2.7.0",

--- a/packages/graphql/src/modules/user/mutations/SaveFacebookUserMutation.ts
+++ b/packages/graphql/src/modules/user/mutations/SaveFacebookUserMutation.ts
@@ -1,7 +1,7 @@
 import {mutationWithClientMutationId} from 'graphql-relay';
 import {GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLString} from 'graphql';
 import AWS from 'aws-sdk';
-import imageToBase64 from 'image-to-base64';
+import {encode} from 'node-base64-image';
 
 import {AWS_S3_BUCKET_NAME} from '../../../common/config';
 import {GraphQLContext} from '../../../types';
@@ -142,9 +142,9 @@ export default mutationWithClientMutationId({
 });
 
 async function uploadProfileImage(url: string, user: UserIncomplete) {
-  const base64Image = await imageToBase64(url);
+  const base64Image = await encode(url);
 
-  const buffer = Buffer.from(base64Image, 'base64');
+  const buffer = base64Image;
 
   const s3 = new AWS.S3();
 
@@ -176,8 +176,8 @@ async function saveOrUpdateProfileImage(dbUser: IUserDocument, profileUrl: strin
       let alreadyExitsOnS3 = false;
 
       for await (const fbImage of fbImages) {
-        const originBase64Image = await imageToBase64(fbImage.originUri);
-        const fbBase64Image = await imageToBase64(fbImage.location);
+        const originBase64Image = await encode(fbImage.originUri);
+        const fbBase64Image = await encode(fbImage.location);
 
         // verify if the current profile image already exists on S3
         if (fbBase64Image == originBase64Image) {


### PR DESCRIPTION
## Summary
Facebook SDK have been updated in #61 and some changes were needed in order to keep it working. One of the things that I need to change was the way how the expires date is stored on database. Before that, the facebook SDK sent the expires date as `int` and now it's returned as a `date`. Besides that, there was a bug on the base64 image parser and the images from UI package didn't appear on android.

## Changelog
- Update facebook SDK syntax
- Get the difference between now and expires date to store it as `int`
- Replace base64 image parser
- Fix android image bug related to [this issue](https://github.com/expo/expo/issues/7545)
