### PR TITLE
fix: some corrections on script for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,17 +72,24 @@ Check the Roadmap to more details about itens below.
 
 ### Getting Started
 
-#### 1) Clone & Install Dependencies
+#### 1) Clone & Install Dependencies on Linux/MacOS
 
 - 1.1) `git clone https://github.com/wendelfreitas/animavita`
 - 1.2) `cd animavita` - cd into your newly created project directory.
 - 1.3) Install NPM packages with `yarn install`
         **Note:** NPM has issues with React Native so `yarn` is recommended over `npm`.
+        
+#### 2) Clone & Install Dependencies on Windows
 
-#### 2) Start your app
+- 2.1) `git clone https://github.com/wendelfreitas/animavita`
+- 2.2) Open the Windows Powershell with Admin permission
+- 2.3) `cd animavita` - cd into your newly created project directory.
+- 2.4) Install NPM packages with `yarn install`
+        
+#### 3) Start your app
 
-- 2.1) **[iOS]** Build and run the iOS app, run `yarn ios`. The first build will take some time.
-- 2.2) **[Android]** If you haven't already got an android device attached/emulator running then you'll need to get one running (make sure the emulator is with Google Play / APIs). When ready run `yarn android` from the root of your project.
+- 3.1) **[iOS]** Build and run the iOS app, run `yarn ios`. The first build will take some time.
+- 3.2) **[Android]** If you haven't already got an android device attached/emulator running then you'll need to get one running (make sure the emulator is with Google Play / APIs). When ready run `yarn android` from the root of your project.
 
 ## :zap: **Tech Stack**
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "expo:test": "yarn workspace @animavita/expo test",
     "graphql": "yarn workspace @animavita/graphql start",
     "graphql:test": "yarn workspace @animavita/graphql test",
-    "postinstall": "patch-package",
+    "postinstall": "cd ./packages/expo && expo-yarn-workspaces postinstall && patch-package",
     "ios": "yarn workspace @animavita/expo ios",
     "lint": "eslint --fix --ext .js,jsx,.ts,.tsx .",
     "lint:ci": "eslint --quiet --ext .js,jsx,.ts,.tsx .",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -7,7 +7,6 @@
     "android": "expo start --android",
     "build:web": "expo build:web",
     "eject": "expo eject",
-    "postinstall": "expo-yarn-workspaces postinstall",
     "ios": "expo start --ios",
     "prepare:build": "scripts/prepareBuild.sh",
     "start": "expo start",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4919,6 +4919,13 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.1.tgz#70a7855888e287f7add66002211a423937063eaf"
   integrity sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==
 
+axios@0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -7230,7 +7237,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0, debug@~3.1.0:
+debug@3.1.0, debug@=3.1.0, debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -9085,6 +9092,13 @@ focus-lock@^0.8.1:
   dependencies:
     tslib "^1.9.3"
 
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
+
 fontfaceobserver@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fontfaceobserver/-/fontfaceobserver-2.1.0.tgz#e2705d293e2c585a6531c2a722905657317a2991"
@@ -10136,13 +10150,6 @@ image-size@^0.6.0:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.6.3.tgz#e7e5c65bb534bd7cdcedd6cb5166272a85f75fb2"
   integrity sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA==
-
-image-to-base64@^2.0.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/image-to-base64/-/image-to-base64-2.1.1.tgz#58c16f88494dfd3e84953cf845a5929be04fbdb5"
-  integrity sha512-G8EZaxl8dmYUXCmaC/1W4oqwj+yiY+qhF9A81TbdOtxdK9BAN3oV440Jofexp4J2oRsbHIUJtl3rlDqdjmiZOQ==
-  dependencies:
-    node-fetch "^2.6.0"
 
 immediate@^3.2.2:
   version "3.3.0"
@@ -13640,6 +13647,13 @@ nocache@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/nocache/-/nocache-2.1.0.tgz#120c9ffec43b5729b1d5de88cd71aa75a0ba491f"
   integrity sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q==
+
+node-base64-image@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/node-base64-image/-/node-base64-image-2.0.1.tgz#8364e46025d95bab087a43e1dc5c3b655072268a"
+  integrity sha512-lXsYTCWsknb4Hvbdv51VQVGkfXWBn57NrR5LgR9wyj7uB6XNefICw2LUDK58lv1erhjHDP1r3l4uGOMnLMtn/g==
+  dependencies:
+    axios "0.19.2"
 
 node-dir@^0.1.10:
   version "0.1.17"


### PR DESCRIPTION
### Summary
Update on the PostInstall Scripts, the script of PostInstall to the Expo integration with Yarn Workspaces had a bug, the command in the package.json of the expo, was removed.  And replaced with a manual command in the main package.json of monorepo.

### Changelog
Removed the PostInstall script of expo/package.json
Added new command on PostInstall script of main package.json of monorepo.

### Related Issues
https://github.com/expo/expo/issues/6983