### PR TITLE
Add adoption list queries

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,4 +5,3 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-

--- a/packages/graphql/src/modules/adoption/AdoptionModel.ts
+++ b/packages/graphql/src/modules/adoption/AdoptionModel.ts
@@ -2,9 +2,22 @@ import mongoose, {Document} from 'mongoose';
 
 const {ObjectId} = mongoose.Types;
 
-type AnimalGenders = 'male' | 'female';
-type AnimalTypes = 'dog' | 'cat' | 'other';
-type AnimalSizes = 'small' | 'medium' | 'big';
+enum AnimalGenders {
+  male = 'male',
+  female = 'female',
+}
+
+enum AnimalTypes {
+  dog = 'dog',
+  cat = 'cat',
+  other = 'other',
+}
+
+enum AnimalSizes {
+  small = 'small',
+  medium = 'medium',
+  big = 'big',
+}
 
 export interface IAdoption {
   user: string;

--- a/packages/graphql/src/modules/adoption/AdoptionModel.ts
+++ b/packages/graphql/src/modules/adoption/AdoptionModel.ts
@@ -1,0 +1,81 @@
+import mongoose, {Document} from 'mongoose';
+
+const {ObjectId} = mongoose.Types;
+
+type AnimalGenders = 'male' | 'female';
+type AnimalTypes = 'dog' | 'cat' | 'other';
+type AnimalSizes = 'small' | 'medium' | 'big';
+
+export interface IAdoption {
+  user: string;
+  name: string;
+  gender: AnimalGenders;
+  breed: string;
+  type: AnimalTypes;
+  age: number;
+  size: AnimalSizes;
+  observations: string;
+  photos: string[];
+}
+
+export type IAdoptionDocument = IAdoption & Document;
+
+const AdoptionSchema = new mongoose.Schema(
+  {
+    user: {
+      type: ObjectId,
+      ref: 'User',
+    },
+    name: {
+      type: String,
+      description: 'Animal name',
+      trim: true,
+      index: true,
+      required: true,
+    },
+    gender: {
+      type: String,
+      description: 'Animal gender',
+      required: true,
+    },
+    breed: {
+      type: String,
+      description: 'Animal breed',
+      trim: true,
+      index: true,
+      required: true,
+    },
+    type: {
+      type: String,
+      description: 'Animal type',
+      required: true,
+    },
+    age: {
+      type: Number,
+      description: 'Animal age',
+      required: true,
+    },
+    size: {
+      type: String,
+      description: 'Animal description',
+      required: true,
+    },
+    photos: [
+      {
+        type: String,
+        description: 'Photos of animal (min: 1)',
+        required: true,
+      },
+    ],
+    observations: {
+      type: String,
+      description: 'Any observation about the animal',
+      maxlength: 200,
+    },
+  },
+  {collection: 'Adoption', timestamps: true},
+);
+
+const AdoptModel = mongoose.model<IAdoptionDocument>('Adopt', AdoptionSchema);
+
+export default AdoptModel;

--- a/packages/graphql/src/modules/adoption/AdoptionQuery.ts
+++ b/packages/graphql/src/modules/adoption/AdoptionQuery.ts
@@ -1,0 +1,28 @@
+import {GraphQLFieldConfigMap, GraphQLList} from 'graphql';
+import {connectionDefinitions, forwardConnectionArgs, connectionFromPromisedArray} from 'graphql-relay';
+
+import {GraphQLContext} from '../../types';
+
+import AdoptModel from './AdoptionModel';
+import AdoptionType from './AdoptionType';
+
+export const AdoptionConnection = connectionDefinitions({
+  name: 'Adoption',
+  nodeType: AdoptionType,
+});
+
+export const AdoptionsQueries: GraphQLFieldConfigMap<any, GraphQLContext, any> = {
+  adoptions: {
+    type: AdoptionConnection.connectionType,
+    args: forwardConnectionArgs,
+    resolve: (_, args) => connectionFromPromisedArray(AdoptModel.find().populate('user') as any, args),
+  },
+  myAdoptions: {
+    type: GraphQLList(AdoptionType),
+    resolve: (_, args, context) => {
+      return AdoptModel.where('user')
+        .equals(context.user?._id)
+        .populate('user');
+    },
+  },
+};

--- a/packages/graphql/src/modules/adoption/AdoptionQuery.ts
+++ b/packages/graphql/src/modules/adoption/AdoptionQuery.ts
@@ -1,10 +1,10 @@
 import {GraphQLFieldConfigMap, GraphQLList} from 'graphql';
-import {connectionDefinitions, forwardConnectionArgs, connectionFromPromisedArray} from 'graphql-relay';
+import {connectionDefinitions, forwardConnectionArgs} from 'graphql-relay';
 
 import {GraphQLContext} from '../../types';
 
-import AdoptModel from './AdoptionModel';
 import AdoptionType from './AdoptionType';
+import AdoptionResolvers from './AdoptionResolvers';
 
 export const AdoptionConnection = connectionDefinitions({
   name: 'Adoption',
@@ -15,14 +15,10 @@ export const AdoptionsQueries: GraphQLFieldConfigMap<any, GraphQLContext, any> =
   adoptions: {
     type: AdoptionConnection.connectionType,
     args: forwardConnectionArgs,
-    resolve: (_, args) => connectionFromPromisedArray(AdoptModel.find().populate('user') as any, args),
+    resolve: AdoptionResolvers.adoption,
   },
   myAdoptions: {
     type: GraphQLList(AdoptionType),
-    resolve: (_, args, context) => {
-      return AdoptModel.where('user')
-        .equals(context.user?._id)
-        .populate('user');
-    },
+    resolve: AdoptionResolvers.myAdoptions,
   },
 };

--- a/packages/graphql/src/modules/adoption/AdoptionResolvers.ts
+++ b/packages/graphql/src/modules/adoption/AdoptionResolvers.ts
@@ -1,0 +1,18 @@
+import {connectionFromPromisedArray} from 'graphql-relay';
+
+import AdoptModel from './AdoptionModel';
+
+const adoption = (_, args) => connectionFromPromisedArray(AdoptModel.find().populate('user') as any, args);
+
+const myAdoptions = (_, __, context) => {
+  return AdoptModel.where('user')
+    .equals(context.user?._id)
+    .populate('user');
+};
+
+const AdoptionResolvers = {
+  adoption,
+  myAdoptions,
+};
+
+export default AdoptionResolvers;

--- a/packages/graphql/src/modules/adoption/AdoptionType.ts
+++ b/packages/graphql/src/modules/adoption/AdoptionType.ts
@@ -1,0 +1,104 @@
+import {
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectTypeConfig,
+  GraphQLEnumType,
+  GraphQLString,
+  GraphQLInt,
+  GraphQLObjectType,
+} from 'graphql';
+import {globalIdField} from 'graphql-relay';
+
+import {registerType, NodeInterface} from '../../interfaces/NodeInterface';
+import {GraphQLContext} from '../../types';
+import UserType from '../user/UserType';
+
+import {IAdoptionDocument} from './AdoptionModel';
+
+type ConfigType = GraphQLObjectTypeConfig<IAdoptionDocument, GraphQLContext>;
+
+export const GenderType = new GraphQLEnumType({
+  name: 'Gender',
+  values: {
+    MALE: {value: 'male'},
+    FEMALE: {value: 'female'},
+  },
+});
+
+export const AnimalTypeType = new GraphQLEnumType({
+  name: 'Type',
+  values: {
+    DOG: {value: 'dog'},
+    CAT: {value: 'cat'},
+    OTHER: {value: 'other'},
+  },
+});
+
+export const AnimalSize = new GraphQLEnumType({
+  name: 'Size',
+  values: {
+    SMALL: {value: 'small'},
+    MEDIUM: {value: 'medium'},
+    BIG: {value: 'big'},
+  },
+});
+
+const AdoptionTypeConfig: ConfigType = {
+  name: 'Adoption',
+  description: 'Animavita adoption',
+  fields: () => ({
+    id: globalIdField('Adoption', adoption => adoption._id),
+    user: {
+      type: GraphQLNonNull(UserType),
+      description: 'The adoption user reference',
+      resolve: adoption => {
+        return adoption.user;
+      },
+    },
+    name: {
+      type: GraphQLNonNull(GraphQLString),
+      description: 'The animal name',
+      resolve: adoption => adoption.name,
+    },
+    gender: {
+      type: GraphQLNonNull(GenderType),
+      description: 'The animal gender',
+      resolve: adoption => adoption.gender,
+    },
+    breed: {
+      type: GraphQLNonNull(GraphQLString),
+      description: 'The animal breed',
+      resolve: adoption => adoption.breed,
+    },
+    type: {
+      type: GraphQLNonNull(AnimalTypeType),
+      description: 'The animal type',
+      resolve: adoption => adoption.type,
+    },
+    age: {
+      type: GraphQLNonNull(GraphQLInt),
+      description: 'The animal age',
+      resolve: adoption => adoption.age,
+    },
+    size: {
+      type: GraphQLNonNull(AnimalSize),
+      description: 'The animal size',
+      resolve: adoption => adoption.size,
+    },
+    photos: {
+      type: GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLString))),
+      description: 'The animal photos',
+      resolve: adoption => adoption.photos,
+    },
+    observations: {
+      type: GraphQLNonNull(GraphQLString),
+      description: 'Any observation about the animal',
+      resolve: adoption => adoption.observations,
+    },
+  }),
+  interfaces: () => [NodeInterface],
+};
+
+const AdoptionType = new GraphQLObjectType(AdoptionTypeConfig);
+
+export default registerType(AdoptionType);

--- a/packages/graphql/src/types/QueryType.ts
+++ b/packages/graphql/src/types/QueryType.ts
@@ -3,6 +3,7 @@ import {GraphQLObjectType} from 'graphql';
 import {GraphQLContext} from '../types';
 import {nodeField} from '../interfaces/NodeInterface';
 import {userQuerys} from '../modules/user/UserQuery';
+import {AdoptionsQueries} from '../modules/adoption/AdoptionQuery';
 
 export default new GraphQLObjectType<any, GraphQLContext, any>({
   name: 'Query',
@@ -10,5 +11,6 @@ export default new GraphQLObjectType<any, GraphQLContext, any>({
   fields: () => ({
     node: nodeField,
     ...userQuerys,
+    ...AdoptionsQueries,
   }),
 });

--- a/packages/schema/schema.graphql
+++ b/packages/schema/schema.graphql
@@ -1,6 +1,62 @@
+"""Animavita adoption"""
+type Adoption implements Node {
+  """The ID of an object"""
+  id: ID!
+
+  """The adoption user reference"""
+  user: User!
+
+  """The animal name"""
+  name: String!
+
+  """The animal gender"""
+  gender: Gender!
+
+  """The animal breed"""
+  breed: String!
+
+  """The animal type"""
+  type: Type!
+
+  """The animal age"""
+  age: Int!
+
+  """The animal size"""
+  size: Size!
+
+  """The animal photos"""
+  photos: [String!]!
+
+  """Any observation about the animal"""
+  observations: String!
+}
+
+"""A connection to a list of items."""
+type AdoptionConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [AdoptionEdge]
+}
+
+"""An edge in a connection."""
+type AdoptionEdge {
+  """The item at the end of the edge"""
+  node: Adoption
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
 type Email {
   email: ID!
   providedBy: String!
+}
+
+enum Gender {
+  MALE
+  FEMALE
 }
 
 type Mutation {
@@ -12,6 +68,21 @@ type Mutation {
 interface Node {
   """The id of the object."""
   id: ID!
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
 }
 
 type ProfileImage {
@@ -35,6 +106,8 @@ type Query {
   ): Node
   user(id: ID!): User
   me: User
+  adoptions(after: String, first: Int): AdoptionConnection
+  myAdoptions: [Adoption]
 }
 
 input SaveFacebookUserInput {
@@ -49,6 +122,18 @@ type SaveFacebookUserPayload {
   user: User
   token: String
   clientMutationId: String
+}
+
+enum Size {
+  SMALL
+  MEDIUM
+  BIG
+}
+
+enum Type {
+  DOG
+  CAT
+  OTHER
 }
 
 """Animavita user"""


### PR DESCRIPTION
closes #74 

#### Why I decided to use `forwardConnectionArgs` instead `connectionArgs`?
Because in the app's home screen slider we can't go back to a previous adoption as shown in [this PR](https://github.com/animavita/animavita/pull/66).

#### CHANGELOG
- Added adoption graphql types and model
- Added missing .editorconfig file
- Updated GraphQL schema

The improved version of [this](https://github.com/animavita/animavita/pull/58).