### PR TITLE
Fix i18n package

### DIFF
--- a/packages/i18n/src/Controller.tsx
+++ b/packages/i18n/src/Controller.tsx
@@ -4,7 +4,7 @@ import i18n from 'i18n-js';
 import locales from '../locales';
 
 interface I18nContextProps {
-  t: (key: string, options: i18n.TranslateOptions) => string;
+  i18n: typeof i18n;
   setLocale: (locale: string) => void;
   locale: string;
 }
@@ -25,7 +25,7 @@ const I18nProvider: React.FC = ({children}) => {
     i18n.translations = locales;
   }, []);
 
-  return <I18nContext.Provider value={{t: i18n.t, setLocale, locale}}>{children}</I18nContext.Provider>;
+  return <I18nContext.Provider value={{i18n, setLocale, locale}}>{children}</I18nContext.Provider>;
 };
 
 const useI18nController = () => {

--- a/packages/i18n/src/__tests__/Controller.test.tsx
+++ b/packages/i18n/src/__tests__/Controller.test.tsx
@@ -20,7 +20,7 @@ describe('I18n Controller', () => {
       result.current.setLocale('en-US');
     });
 
-    const translation = result.current.t('tab_bar.options.settings', {});
+    const translation = result.current.i18n.t('tab_bar.options.settings', {});
     expect(translation).toEqual('Settings');
   });
 });

--- a/packages/i18n/src/useI18n.ts
+++ b/packages/i18n/src/useI18n.ts
@@ -3,14 +3,16 @@ import I18n from 'i18n-js';
 import {useI18nController} from './Controller';
 
 const useI18n = (namespaces: string[]) => {
-  const context = useI18nController();
+  const {i18n, locale} = useI18nController();
 
   const t = (key: string, options: I18n.TranslateOptions = {}) => {
+    i18n.locale = locale;
+
     for (const namespace of namespaces) {
       const searchFor = `${namespace}.${key}`;
-      const translation = context.t(searchFor, options);
+      const translation = i18n.t(searchFor, options);
 
-      const notFound = `[missing "${context.locale}.${searchFor}" translation]`;
+      const notFound = `[missing "${i18n.locale}.${searchFor}" translation]`;
       if (translation !== notFound) return translation;
     }
     return 'Translation not found';


### PR DESCRIPTION
We were with a problem very specific when testing a screen directly rendered in index.ts navigation. The correct locale is saved in Controller as usual, but the t function from the instance was still outdated (we're using i18n-js, a vanilla library).

So the workaround was just to pass the full instance from the Controller and consume it in useI18n. Works fine and performs well