### PR TITLE
fix: fixes s3 missing objects

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -12,7 +12,7 @@
     "start": "expo start",
     "test": "jest",
     "test:watch": "jest --watch",
-    "web": "expo start --web"
+    "web": "expo start --web --https"
   },
   "dependencies": {
     "@animavita/i18n": "1.0.0",
@@ -42,6 +42,7 @@
     "styled-components": "5.0.0"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.2",
     "@expo/webpack-config": "~0.12.45",
     "@testing-library/jest-native": "^3.4.3",
     "@testing-library/react-native": "^7.1.0",
@@ -51,7 +52,6 @@
     "expo-yarn-workspaces": "^1.2.1",
     "jest": "^26.6.3",
     "jest-expo": "^40.0.0",
-    "jest-styled-components": "^7.0.3",
-    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.2"
+    "jest-styled-components": "^7.0.3"
   }
 }

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -38,6 +38,7 @@
     "react-native-reanimated": "~1.13.0",
     "react-native-safe-area-context": "3.1.9",
     "react-native-screens": "~2.15.0",
+    "react-native-url-polyfill": "^1.3.0",
     "react-native-web": "0.13.12",
     "styled-components": "5.0.0"
   },

--- a/packages/expo/src/navigation/Home.tsx
+++ b/packages/expo/src/navigation/Home.tsx
@@ -11,6 +11,7 @@ import Menu, {MenuItem, MenuDivider} from 'react-native-material-menu';
 import {useI18n} from '@animavita/i18n';
 
 import Home from '../modules/home/Home';
+import getEnvVars from '../../../relay/environment';
 
 import {HomeQuery} from './__generated__/HomeQuery.graphql';
 
@@ -52,6 +53,10 @@ const HomeNavigator: React.FC = () => {
   const name = me?.name?.split(' ')[0] || '';
   const imageIndex = me ? me.profileImages.length - 1 : 0;
   const uri = me?.profileImages[imageIndex].url;
+  const uriend = uri.slice(16);
+  const {graphqlApi} = getEnvVars();
+  const uristart = `${graphqlApi}`.slice(0, -5);
+  const finaluri = `${uristart}${uriend}`;
 
   const backgroundColor = theme.themeName === 'light' ? StyledTheme.white : StyledTheme.black;
 
@@ -79,7 +84,7 @@ const HomeNavigator: React.FC = () => {
         ref={menu}
         button={
           <Pressable onPress={showMenu}>
-            <Avatar source={{uri}} />
+            <Avatar source={{uri: finaluri}} />
           </Pressable>
         }>
         <MenuItem onPress={hideMenu} disabled>

--- a/packages/expo/src/navigation/Home.tsx
+++ b/packages/expo/src/navigation/Home.tsx
@@ -1,5 +1,5 @@
 import React, {useRef} from 'react';
-import {Pressable} from 'react-native';
+import {Pressable, Platform} from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {createStackNavigator, StackNavigationOptions} from '@react-navigation/stack';
 import {useNavigation} from '@react-navigation/native';
@@ -9,9 +9,9 @@ import {useLazyLoadQuery, graphql} from '@animavita/relay';
 import {useTheme, px2ddp, StyledTheme} from '@animavita/theme';
 import Menu, {MenuItem, MenuDivider} from 'react-native-material-menu';
 import {useI18n} from '@animavita/i18n';
+import {URL} from 'react-native-url-polyfill';
 
 import Home from '../modules/home/Home';
-import getEnvVars from '../../../relay/environment';
 
 import {HomeQuery} from './__generated__/HomeQuery.graphql';
 
@@ -53,10 +53,18 @@ const HomeNavigator: React.FC = () => {
   const name = me?.name?.split(' ')[0] || '';
   const imageIndex = me ? me.profileImages.length - 1 : 0;
   const uri = me?.profileImages[imageIndex].url;
-  const uriend = uri.slice(16);
-  const {graphqlApi} = getEnvVars();
-  const uristart = `${graphqlApi}`.slice(0, -5);
-  const finaluri = `${uristart}${uriend}`;
+
+  const getPictureUrl = (url: string) => {
+    if (Platform.OS === 'android') {
+      const urlObject = new URL(url);
+      const port = urlObject.port;
+      const pathname = urlObject.pathname;
+
+      return `http://10.0.2.2:${port}/${pathname}`;
+    }
+
+    return url;
+  };
 
   const backgroundColor = theme.themeName === 'light' ? StyledTheme.white : StyledTheme.black;
 
@@ -84,7 +92,7 @@ const HomeNavigator: React.FC = () => {
         ref={menu}
         button={
           <Pressable onPress={showMenu}>
-            <Avatar source={{uri: finaluri}} />
+            <Avatar source={{uri: getPictureUrl(uri)}} />
           </Pressable>
         }>
         <MenuItem onPress={hideMenu} disabled>

--- a/packages/expo/webpack.config.js
+++ b/packages/expo/webpack.config.js
@@ -21,6 +21,7 @@ const nodeDependencies = [
   'expo-localization',
   'expo',
   'react-native-material-menu',
+  'react-native',
 ];
 
 module.exports = async function(env, argv) {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,7 +23,6 @@
     "react-native-ratings": "^7.2.0",
     "react-native-reanimated": "~1.13.0",
     "react-native-svg": "^11.0.1",
-    "react-native-url-polyfill": "^1.3.0",
     "react-native-vector-icons": "^6.6.0",
     "react-native-web": "0.13.12",
     "styled-components": "5.0.0"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,6 +23,7 @@
     "react-native-ratings": "^7.2.0",
     "react-native-reanimated": "~1.13.0",
     "react-native-svg": "^11.0.1",
+    "react-native-url-polyfill": "^1.3.0",
     "react-native-vector-icons": "^6.6.0",
     "react-native-web": "0.13.12",
     "styled-components": "5.0.0"


### PR DESCRIPTION
Fixes #87 

Fixes the S3 missing objects in android devices while using localstack by getting the machine ip set in configuration to create the correct path to load objects. Adds a `--https` to expo web so the user can access facebook correctly while in web version.

* Sample:

![Screenshot_1623763048](https://user-images.githubusercontent.com/61836657/122068090-7aaa4880-cdca-11eb-9f14-dbb6966c6dad.png)
