### PR TITLE
ci: update codecov version

### DIFF
--- a/.github/workflows/test-expo.yml
+++ b/.github/workflows/test-expo.yml
@@ -49,6 +49,4 @@ jobs:
         env:
           JEST_SUITE_NAME: 'Animavita Expo Tests'
           JEST_JUNIT_OUTPUT_DIR: './reports'
-      - uses: codecov/codecov-action@v1.0.2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+      - uses: codecov/codecov-action@v2

--- a/.github/workflows/test-graphql.yml
+++ b/.github/workflows/test-graphql.yml
@@ -43,6 +43,4 @@ jobs:
         env:
           JEST_SUITE_NAME: 'Animavita GraphQL Tests'
           JEST_JUNIT_OUTPUT_DIR: './reports'
-      - uses: codecov/codecov-action@v1.0.2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+      - uses: codecov/codecov-action@v2


### PR DESCRIPTION
### Motivation
We were having issues when uploading coverage. Since codecov [supports tokenless upload](https://about.codecov.io/blog/tokenless-uploads-for-github-actions/) on public repositories, I updated codecov version and removed the secret.
![image](https://user-images.githubusercontent.com/19699724/132246015-87f1cb85-198c-4e25-ba6c-733f7361a42b.png)
