### PR TITLE
Update dockerfile to use node LTS image for backend app

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -22,7 +22,7 @@ RUN pnpm -r build
 FROM base as pruned
 RUN pnpm --filter backend deploy pruned
 
-FROM node:16-alpine
+FROM node:16
 WORKDIR /app
 
 ENV NODE_ENV=development


### PR DESCRIPTION
This is a workaround to solve the below error
![image](https://user-images.githubusercontent.com/19699724/219117020-01beb816-dadb-451e-8817-5dd401b28590.png)

It seems like the LTS image contains the required dependencies for argon2 to work.
We added argon2 in #135 

https://github.com/prisma/prisma/issues/9572