### PR TITLE
Build authentication frontend logic

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -4,6 +4,7 @@ import { I18nextProvider } from 'react-i18next';
 
 import { initI18n } from './src/i18n/i18n.config';
 import MainNavigator from './src/navigation/main-navigator';
+import { AuthProvider } from './src/providers/auth-provider';
 import queryClient from './src/services/query-client-instance';
 import theme from './src/theme';
 
@@ -12,7 +13,9 @@ const App = () => {
     <QueryClientProvider client={queryClient}>
       <NativeBaseProvider theme={theme}>
         <I18nextProvider i18n={initI18n('pt-BR')}>
-          <MainNavigator />
+          <AuthProvider>
+            <MainNavigator />
+          </AuthProvider>
         </I18nextProvider>
       </NativeBaseProvider>
     </QueryClientProvider>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-query": "^4.14.5",
     "axios": "^1.1.3",
     "expo": "~47.0.9",
+    "expo-secure-store": "~12.0.0",
     "expo-status-bar": "~1.4.2",
     "expo-updates": "^0.15.6",
     "i18next": "^22.0.5",

--- a/apps/mobile/src/helpers/secure-store.ts
+++ b/apps/mobile/src/helpers/secure-store.ts
@@ -1,0 +1,25 @@
+import * as SecureStore from 'expo-secure-store';
+
+import { UserToken } from '../providers/auth-provider';
+
+type KeyType = string;
+
+const userTokenKey = 'userToken';
+
+const getValueFor = async <T>(key: KeyType): Promise<T | null> => {
+  const value = await SecureStore.getItemAsync(key);
+  return value ? JSON.parse(value) : null;
+};
+
+const removeValueFor = async (key: KeyType) => {
+  return await SecureStore.deleteItemAsync(key);
+};
+
+const save = async <T>(key: KeyType, value: T) => {
+  const stringfiedValue = JSON.stringify(value);
+  return await SecureStore.setItemAsync(key, stringfiedValue);
+};
+
+export const getUserToken = () => getValueFor<UserToken>(userTokenKey);
+export const removeUserToken = () => removeValueFor(userTokenKey);
+export const saveUserToken = (value: UserToken) => save(userTokenKey, value);

--- a/apps/mobile/src/i18n/locales/pt-BR.json
+++ b/apps/mobile/src/i18n/locales/pt-BR.json
@@ -40,5 +40,10 @@
       "GENDER_REQUIRED": "Informe o sexo do seu Pet",
       "SIZE_REQUIRED": "Informe o porte do seu Pet"
     }
+  },
+  "SIGN_IN": {
+    "FORM": {
+      "LOGIN_BUTTON": "Entrar"
+    }
   }
 }

--- a/apps/mobile/src/navigation/main-navigator.tsx
+++ b/apps/mobile/src/navigation/main-navigator.tsx
@@ -5,15 +5,30 @@ import React from 'react';
 import Routes from '../routes';
 import Home from '../screens/home/home.screen';
 import RegisterAdoption from '../screens/register-adoption/register-adoption.screen';
+import SignInScreen from '../screens/signin/signin.screen';
+import SplashScreen from '../screens/splash/splash.screen';
+import { useAuth } from '../shared/hooks/use-auth-provider';
 
 const Stack = createNativeStackNavigator();
 
 const MainNavigator = () => {
+  const auth = useAuth();
+
+  if (auth.status === 'IDLE') return <SplashScreen />;
+
   return (
     <NavigationContainer>
       <Stack.Navigator screenOptions={{ headerShown: false }} initialRouteName={Routes.Home}>
-        <Stack.Screen name={Routes.Home} component={Home} />
-        <Stack.Screen name={Routes.RegisterAdoption} component={RegisterAdoption} />
+        {auth.status === 'LOGGED' ? (
+          <>
+            <Stack.Screen name={Routes.Home} component={Home} />
+            <Stack.Screen name={Routes.RegisterAdoption} component={RegisterAdoption} />
+          </>
+        ) : (
+          <>
+            <Stack.Screen name={Routes.SignIn} component={SignInScreen} />
+          </>
+        )}
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/apps/mobile/src/providers/auth-provider/auth-provider.reducer.ts
+++ b/apps/mobile/src/providers/auth-provider/auth-provider.reducer.ts
@@ -1,0 +1,20 @@
+import { AuthAction, AuthState } from './auth-provider.types';
+
+const AuthReducer = (state: AuthState, action: AuthAction): AuthState => {
+  switch (action.type) {
+    case 'SIGN_IN':
+      return {
+        ...state,
+        status: 'LOGGED',
+        userToken: action.token,
+      };
+    case 'SIGN_OUT':
+      return {
+        ...state,
+        status: 'NOT_LOGGED',
+        userToken: null,
+      };
+  }
+};
+
+export default AuthReducer;

--- a/apps/mobile/src/providers/auth-provider/auth-provider.test.tsx
+++ b/apps/mobile/src/providers/auth-provider/auth-provider.test.tsx
@@ -22,7 +22,7 @@ const setup = async () =>
     </AuthProvider>
   );
 
-describe('AuthProvider', () => {
+describe('AuthProvider native', () => {
   it('user token is null by default', async () => {
     setup();
 

--- a/apps/mobile/src/providers/auth-provider/auth-provider.test.tsx
+++ b/apps/mobile/src/providers/auth-provider/auth-provider.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+import { AuthContext, AuthProvider } from '.';
+import { getUserToken } from '../../helpers/secure-store';
+
+jest.mock('../../helpers/secure-store', () => ({
+  getUserToken: jest.fn(() => null),
+}));
+
+const setup = async () =>
+  render(
+    <AuthProvider>
+      <AuthContext.Consumer>
+        {(value) => (
+          <>
+            <Text>user token: {JSON.stringify(value.userToken)}</Text>
+            <Text>status: {JSON.stringify(value.status)}</Text>
+          </>
+        )}
+      </AuthContext.Consumer>
+    </AuthProvider>
+  );
+
+describe('AuthProvider', () => {
+  it('user token is null by default', async () => {
+    setup();
+
+    expect(screen.getByText('user token: null')).toBeTruthy();
+
+    await waitForElementToBeRemoved(() => screen.getByText('status: "IDLE"'));
+  });
+
+  it('status is IDLE by default', async () => {
+    setup();
+
+    expect(screen.getByText('status: "IDLE"')).toBeTruthy();
+
+    await waitForElementToBeRemoved(() => screen.getByText('status: "IDLE"'));
+  });
+
+  describe('if no token found', () => {
+    it('logs the user out', async () => {
+      setup();
+
+      await waitForElementToBeRemoved(() => screen.getByText('status: "IDLE"'));
+
+      expect(screen.queryByText('status: "NOT_LOGGED"')).toBeOnTheScreen();
+    });
+  });
+
+  describe('when the token is found', () => {
+    it('logs the user in by storing their token', async () => {
+      (getUserToken as jest.Mock).mockReturnValueOnce('123-abc');
+
+      setup();
+
+      await waitForElementToBeRemoved(() => screen.getByText('status: "IDLE"'));
+
+      expect(screen.queryByText('user token: "123-abc"')).toBeOnTheScreen();
+      expect(screen.queryByText('status: "LOGGED"')).toBeOnTheScreen();
+    });
+  });
+});

--- a/apps/mobile/src/providers/auth-provider/auth-provider.tsx
+++ b/apps/mobile/src/providers/auth-provider/auth-provider.tsx
@@ -1,27 +1,10 @@
-import { useEffect, useReducer, useMemo, createContext } from 'react';
+import { createContext } from 'react';
 
-import { getUserToken, removeUserToken, saveUserToken } from '../../helpers/secure-store';
+import { AuthAction, AuthContextType, AuthState } from './auth-provider.types';
+// if on mobile, use-auth-actions.native.ts will be picked
+import useAuthActions from './use-auth-actions';
 
-export type UserToken = {
-  accessToken: string;
-  refreshToken: string;
-};
-
-type AuthState = {
-  userToken?: UserToken | null;
-  status: 'IDLE' | 'NOT_LOGGED' | 'LOGGED';
-};
-
-type AuthAction = { type: 'SIGN_IN'; token: UserToken } | { type: 'SIGN_OUT' };
-
-type AuthContextActions = {
-  signIn: (token: UserToken) => void;
-  signOut: () => void;
-};
-
-export type AuthContextType = AuthState & AuthContextActions;
-
-const AuthReducer = (state: AuthState, action: AuthAction): AuthState => {
+export const AuthReducer = (state: AuthState, action: AuthAction): AuthState => {
   switch (action.type) {
     case 'SIGN_IN':
       return {
@@ -46,43 +29,7 @@ export const AuthContext = createContext<AuthContextType>({
 });
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
-  const [state, dispatch] = useReducer(AuthReducer, {
-    userToken: null,
-    status: 'IDLE',
-  });
-
-  useEffect(() => {
-    const initState = async () => {
-      try {
-        const userToken = await getUserToken();
-
-        if (userToken !== null) {
-          dispatch({ type: 'SIGN_IN', token: userToken });
-        } else {
-          dispatch({ type: 'SIGN_OUT' });
-        }
-      } catch (e) {
-        // catch error here
-        // Maybe sign_out user!
-      }
-    };
-
-    initState();
-  }, []);
-
-  const authActions: AuthContextActions = useMemo(
-    () => ({
-      signIn: async (token: UserToken) => {
-        dispatch({ type: 'SIGN_IN', token });
-        await saveUserToken(token);
-      },
-      signOut: async () => {
-        await removeUserToken();
-        dispatch({ type: 'SIGN_OUT' });
-      },
-    }),
-    []
-  );
+  const { state, authActions } = useAuthActions();
 
   return (
     <AuthContext.Provider value={{ ...state, ...authActions }}>{children}</AuthContext.Provider>

--- a/apps/mobile/src/providers/auth-provider/auth-provider.tsx
+++ b/apps/mobile/src/providers/auth-provider/auth-provider.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useReducer, useMemo, createContext } from 'react';
+
+import { getUserToken, removeUserToken, saveUserToken } from '../../helpers/secure-store';
+
+export type UserToken = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+type AuthState = {
+  userToken?: UserToken | null;
+  status: 'IDLE' | 'NOT_LOGGED' | 'LOGGED';
+};
+
+type AuthAction = { type: 'SIGN_IN'; token: UserToken } | { type: 'SIGN_OUT' };
+
+type AuthContextActions = {
+  signIn: (token: UserToken) => void;
+  signOut: () => void;
+};
+
+export type AuthContextType = AuthState & AuthContextActions;
+
+const AuthReducer = (state: AuthState, action: AuthAction): AuthState => {
+  switch (action.type) {
+    case 'SIGN_IN':
+      return {
+        ...state,
+        status: 'LOGGED',
+        userToken: action.token,
+      };
+    case 'SIGN_OUT':
+      return {
+        ...state,
+        status: 'NOT_LOGGED',
+        userToken: null,
+      };
+  }
+};
+
+export const AuthContext = createContext<AuthContextType>({
+  status: 'IDLE',
+  userToken: null,
+  signIn: () => {},
+  signOut: () => {},
+});
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [state, dispatch] = useReducer(AuthReducer, {
+    userToken: null,
+    status: 'IDLE',
+  });
+
+  useEffect(() => {
+    const initState = async () => {
+      try {
+        const userToken = await getUserToken();
+
+        if (userToken !== null) {
+          dispatch({ type: 'SIGN_IN', token: userToken });
+        } else {
+          dispatch({ type: 'SIGN_OUT' });
+        }
+      } catch (e) {
+        // catch error here
+        // Maybe sign_out user!
+      }
+    };
+
+    initState();
+  }, []);
+
+  const authActions: AuthContextActions = useMemo(
+    () => ({
+      signIn: async (token: UserToken) => {
+        dispatch({ type: 'SIGN_IN', token });
+        await saveUserToken(token);
+      },
+      signOut: async () => {
+        await removeUserToken();
+        dispatch({ type: 'SIGN_OUT' });
+      },
+    }),
+    []
+  );
+
+  return (
+    <AuthContext.Provider value={{ ...state, ...authActions }}>{children}</AuthContext.Provider>
+  );
+};

--- a/apps/mobile/src/providers/auth-provider/auth-provider.tsx
+++ b/apps/mobile/src/providers/auth-provider/auth-provider.tsx
@@ -1,25 +1,8 @@
 import { createContext } from 'react';
 
-import { AuthAction, AuthContextType, AuthState } from './auth-provider.types';
+import { AuthContextType } from './auth-provider.types';
 // if on mobile, use-auth-actions.native.ts will be picked
 import useAuthActions from './use-auth-actions';
-
-export const AuthReducer = (state: AuthState, action: AuthAction): AuthState => {
-  switch (action.type) {
-    case 'SIGN_IN':
-      return {
-        ...state,
-        status: 'LOGGED',
-        userToken: action.token,
-      };
-    case 'SIGN_OUT':
-      return {
-        ...state,
-        status: 'NOT_LOGGED',
-        userToken: null,
-      };
-  }
-};
 
 export const AuthContext = createContext<AuthContextType>({
   status: 'IDLE',

--- a/apps/mobile/src/providers/auth-provider/auth-provider.types.ts
+++ b/apps/mobile/src/providers/auth-provider/auth-provider.types.ts
@@ -1,0 +1,23 @@
+export type UserToken = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+export type AuthState = {
+  userToken?: UserToken | null;
+  status: 'IDLE' | 'NOT_LOGGED' | 'LOGGED';
+};
+
+export type AuthAction = { type: 'SIGN_IN'; token: UserToken } | { type: 'SIGN_OUT' };
+
+export type AuthContextActions = {
+  signIn: (token: UserToken) => void;
+  signOut: () => void;
+};
+
+export type AuthContextType = AuthState & AuthContextActions;
+
+export type UseAuthActions = {
+  state: AuthState;
+  authActions: AuthContextActions;
+};

--- a/apps/mobile/src/providers/auth-provider/index.ts
+++ b/apps/mobile/src/providers/auth-provider/index.ts
@@ -1,0 +1,1 @@
+export * from './auth-provider';

--- a/apps/mobile/src/providers/auth-provider/use-auth-actions.native.ts
+++ b/apps/mobile/src/providers/auth-provider/use-auth-actions.native.ts
@@ -1,0 +1,53 @@
+import { useEffect, useMemo, useReducer } from 'react';
+
+import { AuthReducer } from './auth-provider';
+import { AuthContextActions, UseAuthActions, UserToken } from './auth-provider.types';
+import { getUserToken, removeUserToken, saveUserToken } from '../../helpers/secure-store';
+
+const useAuthActions = (): UseAuthActions => {
+  const [state, dispatch] = useReducer(AuthReducer, {
+    userToken: null,
+    status: 'IDLE',
+  });
+
+  useEffect(() => {
+    const initState = async () => {
+      try {
+        const userToken = await getUserToken();
+
+        if (userToken !== null) {
+          dispatch({ type: 'SIGN_IN', token: userToken });
+        } else {
+          dispatch({ type: 'SIGN_OUT' });
+        }
+      } catch (e) {
+        // catch error here
+        // Maybe sign_out user!
+        console.error(e);
+      }
+    };
+
+    initState();
+  }, []);
+
+  const authActions: AuthContextActions = useMemo(
+    () => ({
+      signIn: async (token: UserToken) => {
+        dispatch({ type: 'SIGN_IN', token });
+        await saveUserToken(token);
+      },
+      signOut: async () => {
+        await removeUserToken();
+        dispatch({ type: 'SIGN_OUT' });
+      },
+    }),
+    []
+  );
+
+  return {
+    state,
+    authActions,
+  };
+};
+
+export default useAuthActions;

--- a/apps/mobile/src/providers/auth-provider/use-auth-actions.native.ts
+++ b/apps/mobile/src/providers/auth-provider/use-auth-actions.native.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useReducer } from 'react';
 
-import { AuthReducer } from './auth-provider';
+import AuthReducer from './auth-provider.reducer';
 import { AuthContextActions, UseAuthActions, UserToken } from './auth-provider.types';
 import { getUserToken, removeUserToken, saveUserToken } from '../../helpers/secure-store';
 

--- a/apps/mobile/src/providers/auth-provider/use-auth-actions.ts
+++ b/apps/mobile/src/providers/auth-provider/use-auth-actions.ts
@@ -1,0 +1,30 @@
+import { useMemo, useReducer } from 'react';
+
+import { AuthReducer } from './auth-provider';
+import { AuthContextActions, UseAuthActions, UserToken } from './auth-provider.types';
+
+const useAuthActions = (): UseAuthActions => {
+  const [state, dispatch] = useReducer(AuthReducer, {
+    userToken: null,
+    status: 'NOT_LOGGED',
+  });
+
+  const authActions: AuthContextActions = useMemo(
+    () => ({
+      signIn: async (token: UserToken) => {
+        dispatch({ type: 'SIGN_IN', token });
+      },
+      signOut: async () => {
+        dispatch({ type: 'SIGN_OUT' });
+      },
+    }),
+    []
+  );
+
+  return {
+    state,
+    authActions,
+  };
+};
+
+export default useAuthActions;

--- a/apps/mobile/src/providers/auth-provider/use-auth-actions.ts
+++ b/apps/mobile/src/providers/auth-provider/use-auth-actions.ts
@@ -1,6 +1,6 @@
 import { useMemo, useReducer } from 'react';
 
-import { AuthReducer } from './auth-provider';
+import AuthReducer from './auth-provider.reducer';
 import { AuthContextActions, UseAuthActions, UserToken } from './auth-provider.types';
 
 const useAuthActions = (): UseAuthActions => {

--- a/apps/mobile/src/routes.ts
+++ b/apps/mobile/src/routes.ts
@@ -1,6 +1,7 @@
 const Routes = {
   Home: 'Home',
   RegisterAdoption: 'RegisterAdoption',
+  SignIn: 'SignIn',
 };
 
 export default Routes;

--- a/apps/mobile/src/screens/home/home.screen.tsx
+++ b/apps/mobile/src/screens/home/home.screen.tsx
@@ -5,10 +5,11 @@ import useAdoptions from '../../hooks/use-adoptions';
 import Routes from '../../routes';
 import client from '../../services/http-client';
 import AppStatusBar from '../../shared/components/status-bar/status-bar.component';
+import { useAuth } from '../../shared/hooks/use-auth-provider';
 
 const Home = () => {
   const navigation = useNavigation();
-
+  const auth = useAuth();
   const { adoptions, loading } = useAdoptions();
 
   return (
@@ -23,6 +24,14 @@ const Home = () => {
         }}
       >
         Register Adoption
+      </Button>
+      <Button
+        variant="outline"
+        onPress={() => {
+          auth.signOut();
+        }}
+      >
+        Sair
       </Button>
       {loading && <Text>Loading...</Text>}
       {adoptions && (

--- a/apps/mobile/src/screens/signin/signin.screen.tsx
+++ b/apps/mobile/src/screens/signin/signin.screen.tsx
@@ -1,0 +1,27 @@
+import { Button, View } from 'native-base';
+
+import AppStatusBar from '../../shared/components/status-bar/status-bar.component';
+import { useAuth } from '../../shared/hooks/use-auth-provider';
+
+const SignInScreen = () => {
+  const auth = useAuth();
+
+  return (
+    <View flex="1" alignItems="center" justifyContent="center">
+      <AppStatusBar />
+      <Button
+        variant="outline"
+        onPress={() => {
+          auth.signIn({
+            accessToken: '1234',
+            refreshToken: '4321',
+          });
+        }}
+      >
+        Entrar
+      </Button>
+    </View>
+  );
+};
+
+export default SignInScreen;

--- a/apps/mobile/src/screens/signin/signin.screen.tsx
+++ b/apps/mobile/src/screens/signin/signin.screen.tsx
@@ -2,9 +2,11 @@ import { Button, View } from 'native-base';
 
 import AppStatusBar from '../../shared/components/status-bar/status-bar.component';
 import { useAuth } from '../../shared/hooks/use-auth-provider';
+import useLocale from '../../shared/hooks/use-locale';
 
 const SignInScreen = () => {
   const auth = useAuth();
+  const { t } = useLocale();
 
   return (
     <View flex="1" alignItems="center" justifyContent="center">
@@ -18,7 +20,7 @@ const SignInScreen = () => {
           });
         }}
       >
-        Entrar
+        {t('SIGN_IN.FORM.LOGIN_BUTTON')}
       </Button>
     </View>
   );

--- a/apps/mobile/src/screens/splash/splash.screen.tsx
+++ b/apps/mobile/src/screens/splash/splash.screen.tsx
@@ -1,9 +1,9 @@
-import { Text, View } from 'native-base';
+import { View, Spinner } from 'native-base';
 
 const SplashScreen = () => {
   return (
-    <View flex="1" alignItems="center" justifyContent="center" bg="danger.800">
-      <Text>Carregando...</Text>
+    <View flex="1" alignItems="center" justifyContent="center">
+      <Spinner size="lg" />
     </View>
   );
 };

--- a/apps/mobile/src/screens/splash/splash.screen.tsx
+++ b/apps/mobile/src/screens/splash/splash.screen.tsx
@@ -1,0 +1,11 @@
+import { Text, View } from 'native-base';
+
+const SplashScreen = () => {
+  return (
+    <View flex="1" alignItems="center" justifyContent="center" bg="danger.800">
+      <Text>Carregando...</Text>
+    </View>
+  );
+};
+
+export default SplashScreen;

--- a/apps/mobile/src/shared/hooks/use-auth-provider.ts
+++ b/apps/mobile/src/shared/hooks/use-auth-provider.ts
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+
+import { AuthContext, AuthContextType } from '../../providers/auth-provider/auth-provider';
+
+export const useAuth = (): AuthContextType => {
+  const context = useContext(AuthContext);
+
+  if (!context) {
+    throw new Error('useAuth must be inside an AuthProvider with a value');
+  }
+
+  return context;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,7 @@ importers:
       eslint-plugin-prefer-arrow: ^1.2.3
       eslint-plugin-prettier: ^4.0.0
       expo: ~47.0.9
+      expo-secure-store: ~12.0.0
       expo-status-bar: ~1.4.2
       expo-updates: ^0.15.6
       i18next: ^22.0.5
@@ -152,6 +153,7 @@ importers:
       '@tanstack/react-query': 4.24.4_2bkajway7msrchxwrvhplxy5ru
       axios: 1.1.3
       expo: 47.0.13_@babel+core@7.19.6
+      expo-secure-store: 12.0.0_expo@47.0.13
       expo-status-bar: 1.4.2
       expo-updates: 0.15.6_expo@47.0.13
       i18next: 22.4.9
@@ -161,7 +163,7 @@ importers:
       react-dom: 18.1.0_react@18.1.0
       react-hook-form: 7.43.1_react@18.1.0
       react-i18next: 12.1.5_vs42nc5a2zne2fuf76h7qaykcy
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
       react-native-gesture-handler: 2.9.0_tj3nonr5gneraukzjkxpsiy7yu
       react-native-safe-area-context: 4.4.1_tj3nonr5gneraukzjkxpsiy7yu
       react-native-screens: 3.18.2_tj3nonr5gneraukzjkxpsiy7yu
@@ -3961,7 +3963,7 @@ packages:
       '@react-stately/toggle': 3.2.1_react@18.1.0
       '@react-types/checkbox': 3.4.1_react@18.1.0
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
     dev: false
 
   /@react-native-aria/checkbox/0.2.3_tj3nonr5gneraukzjkxpsiy7yu:
@@ -3976,7 +3978,7 @@ packages:
       '@react-native-aria/utils': 0.2.8_tj3nonr5gneraukzjkxpsiy7yu
       '@react-stately/toggle': 3.2.1_react@18.1.0
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
     dev: false
 
   /@react-native-aria/combobox/0.2.4-alpha.1_2bkajway7msrchxwrvhplxy5ru:
@@ -3992,7 +3994,7 @@ packages:
       '@react-native-aria/utils': 0.2.8_tj3nonr5gneraukzjkxpsiy7yu
       '@react-types/button': 3.7.0_react@18.1.0
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
     transitivePeerDependencies:
       - react-dom
     dev: false
@@ -4005,7 +4007,7 @@ packages:
     dependencies:
       '@react-aria/focus': 3.10.1_react@18.1.0
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
     dev: false
 
   /@react-native-aria/interactions/0.2.8_tj3nonr5gneraukzjkxpsiy7yu:
@@ -4018,7 +4020,7 @@ packages:
       '@react-aria/utils': 3.14.2_react@18.1.0
       '@react-native-aria/utils': 0.2.8_tj3nonr5gneraukzjkxpsiy7yu
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
     dev: false
 
   /@react-native-aria/listbox/0.2.4-alpha.3_tj3nonr5gneraukzjkxpsiy7yu:
@@ -4037,7 +4039,7 @@ packages:
       '@react-types/listbox': 3.3.5_react@18.1.0
       '@react-types/shared': 3.16.0_react@18.1.0
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
     dev: false
 
   /@react-native-aria/overlays/0.3.3-rc.0_2bkajway7msrchxwrvhplxy5ru:
@@ -4055,7 +4057,7 @@ packages:
       dom-helpers: 5.2.1
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
     dev: false
 
   /@react-native-aria/radio/0.2.5_tj3nonr5gneraukzjkxpsiy7yu:
@@ -4071,7 +4073,7 @@ packages:
       '@react-stately/radio': 3.2.1_react@18.1.0
       '@react-types/radio': 3.3.1_react@18.1.0
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
     dev: false
 
   /@react-native-aria/slider/0.2.5-alpha.2_tj3nonr5gneraukzjkxpsiy7yu:
@@ -4088,7 +4090,7 @@ packages:
       '@react-native-aria/utils': 0.2.8_tj3nonr5gneraukzjkxpsiy7yu
       '@react-stately/slider': 3.0.1_react@18.1.0
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
     dev: false
 
   /@react-native-aria/tabs/0.2.8_tj3nonr5gneraukzjkxpsiy7yu:
@@ -4104,7 +4106,7 @@ packages:
       '@react-stately/tabs': 3.0.0-alpha.1_react@18.1.0
       '@react-types/tabs': 3.0.0-alpha.2_react@18.1.0
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
     dev: false
 
   /@react-native-aria/toggle/0.2.3_tj3nonr5gneraukzjkxpsiy7yu:
@@ -4120,7 +4122,7 @@ packages:
       '@react-stately/toggle': 3.4.4_react@18.1.0
       '@react-types/checkbox': 3.4.1_react@18.1.0
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
     dev: false
 
   /@react-native-aria/utils/0.2.8_tj3nonr5gneraukzjkxpsiy7yu:
@@ -4132,7 +4134,7 @@ packages:
       '@react-aria/ssr': 3.4.1_react@18.1.0
       '@react-aria/utils': 3.14.2_react@18.1.0
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
     dev: false
 
   /@react-native-community/cli-clean/9.2.1:
@@ -4244,7 +4246,7 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@react-native-community/cli-plugin-metro/9.2.1_@babel+core@7.19.6:
+  /@react-native-community/cli-plugin-metro/9.2.1:
     resolution: {integrity: sha512-byBGBH6jDfUvcHGFA45W/sDwMlliv7flJ8Ns9foCh3VsIeYYPoDjjK7SawE9cPqRdMAD4SY7EVwqJnOtRbwLiQ==}
     dependencies:
       '@react-native-community/cli-server-api': 9.2.1
@@ -4253,12 +4255,11 @@ packages:
       metro: 0.72.3
       metro-config: 0.72.3
       metro-core: 0.72.3
-      metro-react-native-babel-transformer: 0.72.3_@babel+core@7.19.6
+      metro-react-native-babel-transformer: 0.72.3
       metro-resolver: 0.72.3
       metro-runtime: 0.72.3
       readline: 1.3.0
     transitivePeerDependencies:
-      - '@babel/core'
       - bufferutil
       - encoding
       - supports-color
@@ -4302,7 +4303,7 @@ packages:
     dependencies:
       joi: 17.6.4
 
-  /@react-native-community/cli/9.2.1_@babel+core@7.19.6:
+  /@react-native-community/cli/9.2.1:
     resolution: {integrity: sha512-feMYS5WXXKF4TSWnCXozHxtWq36smyhGaENXlkiRESfYZ1mnCUlPfOanNCAvNvBqdyh9d4o0HxhYKX1g9l6DCQ==}
     engines: {node: '>=14'}
     hasBin: true
@@ -4312,7 +4313,7 @@ packages:
       '@react-native-community/cli-debugger-ui': 9.0.0
       '@react-native-community/cli-doctor': 9.3.0
       '@react-native-community/cli-hermes': 9.3.1
-      '@react-native-community/cli-plugin-metro': 9.2.1_@babel+core@7.19.6
+      '@react-native-community/cli-plugin-metro': 9.2.1
       '@react-native-community/cli-server-api': 9.2.1
       '@react-native-community/cli-tools': 9.2.1
       '@react-native-community/cli-types': 9.1.0
@@ -4325,7 +4326,6 @@ packages:
       prompts: 2.4.2
       semver: 6.3.0
     transitivePeerDependencies:
-      - '@babel/core'
       - bufferutil
       - encoding
       - supports-color
@@ -4364,7 +4364,7 @@ packages:
     dependencies:
       '@react-navigation/native': 6.1.3_tj3nonr5gneraukzjkxpsiy7yu
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
       react-native-safe-area-context: 4.4.1_tj3nonr5gneraukzjkxpsiy7yu
     dev: false
 
@@ -4380,7 +4380,7 @@ packages:
       '@react-navigation/elements': 1.3.14_w2cizg437d66bc7wzdfp5thmbu
       '@react-navigation/native': 6.1.3_tj3nonr5gneraukzjkxpsiy7yu
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
       react-native-safe-area-context: 4.4.1_tj3nonr5gneraukzjkxpsiy7yu
       react-native-screens: 3.18.2_tj3nonr5gneraukzjkxpsiy7yu
       warn-once: 0.1.1
@@ -4397,7 +4397,7 @@ packages:
       fast-deep-equal: 3.1.3
       nanoid: 3.3.4
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
     dev: false
 
   /@react-navigation/routers/6.1.6:
@@ -4935,7 +4935,7 @@ packages:
       '@tanstack/query-core': 4.24.4
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
       use-sync-external-store: 1.2.0_react@18.1.0
     dev: false
 
@@ -4951,7 +4951,7 @@ packages:
       jest-matcher-utils: 29.4.2
       pretty-format: 29.4.2
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
       react-test-renderer: 18.2.0_react@18.1.0
       redent: 3.0.0
     dev: true
@@ -4994,7 +4994,7 @@ packages:
       jest: 28.1.3
       pretty-format: 29.4.2
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
       react-test-renderer: 18.2.0_react@18.1.0
     dev: true
 
@@ -6393,7 +6393,7 @@ packages:
       '@babel/preset-env': 7.19.4_@babel+core@7.19.6
       babel-plugin-module-resolver: 4.1.0
       babel-plugin-react-native-web: 0.18.9
-      metro-react-native-babel-preset: 0.72.3_@babel+core@7.19.6
+      metro-react-native-babel-preset: 0.72.3
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -8985,6 +8985,14 @@ packages:
       update-check: 1.5.3
     transitivePeerDependencies:
       - encoding
+    dev: false
+
+  /expo-secure-store/12.0.0_expo@47.0.13:
+    resolution: {integrity: sha512-Rz5lYr2NxrnFvIPwuWcseUSbdUjFxNZG0oVulqM9puuK7t5lDG3/SAy+J22ELBhaltuci2VVO6hCdFwRoRiG/Q==}
+    peerDependencies:
+      expo: '*'
+    dependencies:
+      expo: 47.0.13_@babel+core@7.19.6
     dev: false
 
   /expo-status-bar/1.4.2:
@@ -12314,10 +12322,8 @@ packages:
     dependencies:
       uglify-es: 3.3.9
 
-  /metro-react-native-babel-preset/0.72.3_@babel+core@7.19.6:
+  /metro-react-native-babel-preset/0.72.3:
     resolution: {integrity: sha512-uJx9y/1NIqoYTp6ZW1osJ7U5ZrXGAJbOQ/Qzl05BdGYvN1S7Qmbzid6xOirgK0EIT0pJKEEh1s8qbassYZe4cw==}
-    peerDependencies:
-      '@babel/core': '*'
     dependencies:
       '@babel/core': 7.19.6
       '@babel/plugin-proposal-async-generator-functions': 7.19.1_@babel+core@7.19.6
@@ -12361,16 +12367,14 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /metro-react-native-babel-transformer/0.72.3_@babel+core@7.19.6:
+  /metro-react-native-babel-transformer/0.72.3:
     resolution: {integrity: sha512-Ogst/M6ujYrl/+9mpEWqE3zF7l2mTuftDTy3L8wZYwX1pWUQWQpfU1aJBeWiLxt1XlIq+uriRjKzKoRoIK57EA==}
-    peerDependencies:
-      '@babel/core': '*'
     dependencies:
       '@babel/core': 7.19.6
       babel-preset-fbjs: 3.4.0_@babel+core@7.19.6
       hermes-parser: 0.8.0
       metro-babel-transformer: 0.72.3
-      metro-react-native-babel-preset: 0.72.3_@babel+core@7.19.6
+      metro-react-native-babel-preset: 0.72.3
       metro-source-map: 0.72.3
       nullthrows: 1.1.1
     transitivePeerDependencies:
@@ -12484,7 +12488,7 @@ packages:
       metro-hermes-compiler: 0.72.3
       metro-inspector-proxy: 0.72.3
       metro-minify-uglify: 0.72.3
-      metro-react-native-babel-preset: 0.72.3_@babel+core@7.19.6
+      metro-react-native-babel-preset: 0.72.3
       metro-resolver: 0.72.3
       metro-runtime: 0.72.3
       metro-source-map: 0.72.3
@@ -13000,7 +13004,7 @@ packages:
       lodash.pick: 4.4.0
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
       react-native-safe-area-context: 4.4.1_tj3nonr5gneraukzjkxpsiy7yu
       react-native-svg: 13.4.0_tj3nonr5gneraukzjkxpsiy7yu
       stable-hash: 0.0.2
@@ -14380,12 +14384,6 @@ packages:
   /react-dev-utils/11.0.4_q4ym3cu5jqzfuv3aqtrbuixqz4:
     resolution: {integrity: sha512-dx0LvIGHcOPtKbeiSUM4jqpBl3TcY7CDjZdfOIcKeznE7BWr9dg0iPG90G5yfVQ+p/rGNMXdbfStvzQZEVEi4A==}
     engines: {node: '>=10'}
-    peerDependencies:
-      typescript: '>=2.7'
-      webpack: '>=4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
     dependencies:
       '@babel/code-frame': 7.10.4
       address: 1.1.2
@@ -14416,7 +14414,9 @@ packages:
     transitivePeerDependencies:
       - eslint
       - supports-color
+      - typescript
       - vue-template-compiler
+      - webpack
     dev: false
 
   /react-devtools-core/4.24.0:
@@ -14487,7 +14487,7 @@ packages:
       i18next: 22.4.9
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
     dev: false
 
   /react-is/16.13.1:
@@ -14522,7 +14522,7 @@ packages:
       lodash: 4.17.21
       prop-types: 15.8.1
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
     dev: false
 
   /react-native-gradle-plugin/0.70.3:
@@ -14535,7 +14535,7 @@ packages:
       react-native: '*'
     dependencies:
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
     dev: false
 
   /react-native-screens/3.18.2_tj3nonr5gneraukzjkxpsiy7yu:
@@ -14546,7 +14546,7 @@ packages:
     dependencies:
       react: 18.1.0
       react-freeze: 1.0.3_react@18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
       warn-once: 0.1.1
     dev: false
 
@@ -14555,7 +14555,7 @@ packages:
     peerDependencies:
       react-native: '*'
     dependencies:
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
     dev: false
 
   /react-native-svg/13.4.0_tj3nonr5gneraukzjkxpsiy7yu:
@@ -14567,7 +14567,7 @@ packages:
       css-select: 5.1.0
       css-tree: 1.1.3
       react: 18.1.0
-      react-native: 0.70.5_5m5cnkzycncoaebvnxypxhevq4
+      react-native: 0.70.5_6rk6wbi5chodhfv4sxty5t2afq
     dev: false
 
   /react-native-vector-icons/9.2.0:
@@ -14597,7 +14597,7 @@ packages:
       - encoding
     dev: false
 
-  /react-native/0.70.5_5m5cnkzycncoaebvnxypxhevq4:
+  /react-native/0.70.5_6rk6wbi5chodhfv4sxty5t2afq:
     resolution: {integrity: sha512-5NZM80LC3L+TIgQX/09yiyy48S73wMgpIgN5cCv3XTMR394+KpDI3rBZGH4aIgWWuwijz31YYVF5504+9n2Zfw==}
     engines: {node: '>=14'}
     hasBin: true
@@ -14605,7 +14605,7 @@ packages:
       react: 18.1.0
     dependencies:
       '@jest/create-cache-key-function': 29.4.2
-      '@react-native-community/cli': 9.2.1_@babel+core@7.19.6
+      '@react-native-community/cli': 9.2.1
       '@react-native-community/cli-platform-android': 9.2.1
       '@react-native-community/cli-platform-ios': 9.2.1
       '@react-native/assets': 1.0.0
@@ -14618,7 +14618,7 @@ packages:
       invariant: 2.2.4
       jsc-android: 250230.2.1
       memoize-one: 5.2.1
-      metro-react-native-babel-transformer: 0.72.3_@babel+core@7.19.6
+      metro-react-native-babel-transformer: 0.72.3
       metro-runtime: 0.72.3
       metro-source-map: 0.72.3
       mkdirp: 0.5.6
@@ -14638,7 +14638,6 @@ packages:
       whatwg-fetch: 3.6.2
       ws: 6.2.2
     transitivePeerDependencies:
-      - '@babel/core'
       - '@babel/preset-env'
       - bufferutil
       - encoding


### PR DESCRIPTION
### Overview
This is supposed to create the logic to show the sign-in or internal screens such as home, adoption register, etc. In a nutshell, I added a new `AuthProvider` that is responsible to handle the authentication flow and to know whether render the sign-in or the internal routes, we basically have a condition in the `MainNavigator` component watching the `auth.status` state.

### Storage approach
I decided to use `expo-secure-store` to store the user's JWT token since it seems to be the most popular approach being used.

### On web
For now, since we won't have a lot of users coming from the web, I decided not to store the user's token on any storage system because doing so, we're susceptible to XSS attacks and our backend doesn't support an HttpOnly cookie, which would be ideally better. Therefore, for now, we're gonna have the token in memory, and users that want to use Animavita on the web will have to log in every time they refresh the page.

### Platform-specific code
As you may already noticed, we're taking different auth approaches depending on where the user is using the app. For this reason, I tried to avoid conditionals and isolated the code for native and web in two different files: `use-auth-actions.native.ts` and `use-auth-actions.native.ts`. This way we can easily change the code for one platform without impacting another.