### PR TITLE
Improve adoptions screen UX

### DIFF
--- a/apps/backend/src/adoption/adoption.controller.ts
+++ b/apps/backend/src/adoption/adoption.controller.ts
@@ -1,4 +1,3 @@
-import { AdoptionType } from '@animavita/models';
 import {
   adoptionValidationSchema,
   createValidationSchema,

--- a/apps/backend/src/adoption/repositories/mongodb/adoption-mongo.schema.ts
+++ b/apps/backend/src/adoption/repositories/mongodb/adoption-mongo.schema.ts
@@ -8,7 +8,7 @@ export const AdoptionSchema = new mongoose.Schema<AdoptionDocument>(
     gender: String,
     breed: String,
     type: String,
-    age: Number,
+    age: String,
     size: String,
     observations: String,
     photos: [String],

--- a/apps/backend/test/mocks/adoptions.ts
+++ b/apps/backend/test/mocks/adoptions.ts
@@ -2,7 +2,7 @@ import { AdoptionType, UserType } from '@animavita/models';
 
 export const pet1Mock: AdoptionType = {
   name: 'Bob',
-  age: 4,
+  age: 'puppy',
   type: 'dog',
   breed: 'Rottweiler',
   gender: 'male',
@@ -13,7 +13,7 @@ export const pet1Mock: AdoptionType = {
 
 export const pet2Mock: AdoptionType = {
   name: 'Max',
-  age: 2,
+  age: 'young',
   type: 'cat',
   breed: 'Birman',
   gender: 'male',
@@ -24,7 +24,7 @@ export const pet2Mock: AdoptionType = {
 
 export const pet3Mock: AdoptionType = {
   name: 'Lucy',
-  age: 1,
+  age: 'adult',
   type: 'dog',
   breed: 'Bulldog',
   gender: 'female',

--- a/apps/mobile/src/components/react-hook-form/native-base/rhf-native-input.tsx
+++ b/apps/mobile/src/components/react-hook-form/native-base/rhf-native-input.tsx
@@ -8,11 +8,17 @@ type RHFNativeBaseInputProps = {
   name: string;
 };
 
-const RHFNativeBaseInput = ({ control, name, input }: RHFNativeBaseInputProps) => {
-  const { field } = useController({ control, name });
+const RHFNativeBaseInput = ({ control, name, input, ...props }: RHFNativeBaseInputProps) => {
+  const { field, fieldState } = useController({ control, name });
 
   return (
-    <Input {...input} value={field.value} onChangeText={field.onChange} onBlur={field.onBlur} />
+    <Input
+      {...input}
+      value={field.value}
+      onChangeText={field.onChange}
+      onBlur={field.onBlur}
+      isInvalid={fieldState.invalid}
+    />
   );
 };
 

--- a/apps/mobile/src/components/register-adoption-form/adoption-form.component.test.tsx
+++ b/apps/mobile/src/components/register-adoption-form/adoption-form.component.test.tsx
@@ -37,7 +37,7 @@ const goToLastStep = async () => {
   forwardStep();
   await pickOptionFromList(/c[aã]o/gi);
   forwardStep();
-  await screen.findByTestId('adoption-form-age-input');
+  await pickOptionFromList(/filhote \(menos de 1 ano\)/i);
   forwardStep();
   await pickOptionFromList(/macho/i);
   forwardStep();

--- a/apps/mobile/src/components/register-adoption-form/adoption-form.component.tsx
+++ b/apps/mobile/src/components/register-adoption-form/adoption-form.component.tsx
@@ -1,9 +1,10 @@
 import { AdoptionType } from '@animavita/models';
 import { createValidationSchema } from '@animavita/validation-schemas';
 import { joiResolver } from '@hookform/resolvers/joi';
-import { Box, useToast } from 'native-base';
+import { Box, KeyboardAvoidingView, useToast } from 'native-base';
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
+import { Platform } from 'react-native';
 
 import { AdoptionSteps } from './adoption-form.types';
 import FormSteps from './compose/form-steps';
@@ -12,7 +13,6 @@ import StepperIndicator from './compose/stepper-indicator';
 import { useMultiStepNavigation } from './hooks/use-multi-step-navigation.hook';
 import useAdoptions from '../../hooks/use-adoptions';
 import Delimiter from '../delimiter';
-import SafeArea from '../safe-area/safe-area';
 
 type RegisterAdoptionFormProps = {
   defaultValues?: Partial<AdoptionType>;
@@ -25,7 +25,7 @@ const RegisterAdoptionForm = ({ defaultValues, initialStep }: RegisterAdoptionFo
 
   const adoptionForm = useForm<Partial<AdoptionType>>({
     resolver: joiResolver(createValidationSchema),
-    mode: 'onBlur',
+    mode: 'onChange',
     defaultValues,
   });
   const { saveOrCreateAdoption, saving } = useAdoptions();
@@ -47,34 +47,32 @@ const RegisterAdoptionForm = ({ defaultValues, initialStep }: RegisterAdoptionFo
   };
 
   return (
-    <Box height="full">
-      <SafeArea>
-        <FormProvider {...adoptionForm}>
-          <StepperIndicator activeStep={activeStep} />
-          <Delimiter marginTop={0} flex="1">
-            <Box
-              position="relative"
-              marginTop="8"
-              display="flex"
-              flex-direction="column"
-              justify-content="center"
-            >
-              <FormSteps activeStep={activeStep} />
-            </Box>
+    <KeyboardAvoidingView flex="1" behavior="padding" enabled={Platform.OS === 'ios'}>
+      <FormProvider {...adoptionForm}>
+        <StepperIndicator activeStep={activeStep} />
+        <Delimiter marginTop={0} flex="1">
+          <Box
+            position="relative"
+            marginTop="8"
+            display="flex"
+            flex-direction="column"
+            justify-content="center"
+          >
+            <FormSteps activeStep={activeStep} />
+          </Box>
 
-            <StepperController
-              isLastStep={isLastStep}
-              isFirstStep={isFirstStep}
-              activeStep={activeStep}
-              saving={saving}
-              handleBack={handleBack}
-              handleNext={handleNext}
-              onConfirm={onConfirm}
-            />
-          </Delimiter>
-        </FormProvider>
-      </SafeArea>
-    </Box>
+          <StepperController
+            isLastStep={isLastStep}
+            isFirstStep={isFirstStep}
+            activeStep={activeStep}
+            saving={saving}
+            handleBack={handleBack}
+            handleNext={handleNext}
+            onConfirm={onConfirm}
+          />
+        </Delimiter>
+      </FormProvider>
+    </KeyboardAvoidingView>
   );
 };
 

--- a/apps/mobile/src/components/register-adoption-form/adoption-form.constants.ts
+++ b/apps/mobile/src/components/register-adoption-form/adoption-form.constants.ts
@@ -6,7 +6,7 @@ export const stepsLibrary: {
   PetName: { order: 0, label: 'REGISTER_ADOPTION.FORM.NAME', fieldName: 'name' },
   PetBreed: { order: 1, label: 'REGISTER_ADOPTION.FORM.BREED', fieldName: 'breed' },
   PetType: { order: 2, label: 'REGISTER_ADOPTION.FORM.TYPE_OPTIONS.LABEL', fieldName: 'type' },
-  PetAge: { order: 3, label: 'REGISTER_ADOPTION.FORM.AGE', fieldName: 'age' },
+  PetAge: { order: 3, label: 'REGISTER_ADOPTION.FORM.AGE_OPTIONS.LABEL', fieldName: 'age' },
   PetGender: { order: 4, label: 'REGISTER_ADOPTION.FORM.GENDER.LABEL', fieldName: 'gender' },
   PetSize: { order: 5, label: 'REGISTER_ADOPTION.FORM.SIZE.LABEL', fieldName: 'size' },
   PetPhotos: {

--- a/apps/mobile/src/components/register-adoption-form/compose/form-steps/form-steps.tsx
+++ b/apps/mobile/src/components/register-adoption-form/compose/form-steps/form-steps.tsx
@@ -1,6 +1,5 @@
-import { Box, Slider, Text } from 'native-base';
 import React from 'react';
-import { useFormContext, useWatch } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 
 import PetUploadPhotosStep from './pet-upload-photos-step/pet-upload-photos-step.component';
 import useLocale from '../../../../hooks/use-locale';
@@ -26,6 +25,8 @@ const PetNameStep = () => {
         ...commonInputProperties,
         placeholder: t('REGISTER_ADOPTION.FORM.NAME_PLACEHOLDER'),
         testID: 'adoption-form-name-input',
+        returnKeyType: 'next',
+        isRequired: true,
       }}
       control={control}
       name={stepsLibrary.PetName.fieldName}
@@ -81,31 +82,13 @@ const PetTypeStep = () => {
 
 const PetAgeStep = () => {
   const { t } = useLocale();
-  const { setValue } = useFormContext();
-  const fieldName = stepsLibrary.PetAge.fieldName;
-  const petAgeValue = useWatch({ name: fieldName });
 
-  return (
-    <Box>
-      <Slider
-        w="full"
-        defaultValue={petAgeValue}
-        onChangeEnd={(value) => setValue(fieldName, value)}
-        minValue={0}
-        maxValue={100}
-        accessibilityLabel={t('REGISTER_ADOPTION.FORM.AGE')}
-        testID="adoption-form-age-input"
-      >
-        <Slider.Track>
-          <Slider.FilledTrack />
-        </Slider.Track>
-        <Slider.Thumb />
-      </Slider>
-      <Text textAlign="right">
-        {petAgeValue} {t('YEAR')}
-      </Text>
-    </Box>
-  );
+  const options = ['PUPPY', 'YOUNG', 'ADULT', 'SENIOR'].map((type) => ({
+    label: t(`REGISTER_ADOPTION.FORM.AGE_OPTIONS.${type}`),
+    value: type,
+  }));
+
+  return <RHFListSelector name={stepsLibrary.PetAge.fieldName} options={options} />;
 };
 
 const PetSizeStep = () => {

--- a/apps/mobile/src/components/register-adoption-form/compose/stepper-controller/stepper-controller.tsx
+++ b/apps/mobile/src/components/register-adoption-form/compose/stepper-controller/stepper-controller.tsx
@@ -12,7 +12,6 @@ const StepperController = ({
   handleNext,
   onConfirm,
   isLastStep,
-  isFirstStep,
   activeStep,
   saving,
 }: StepperControllerProps) => {
@@ -35,9 +34,18 @@ const StepperController = ({
     if (isValid) handleNext();
   };
 
+  const label = isLastStep
+    ? t('REGISTER_ADOPTION.FORM.CONFIRM_BUTTON')
+    : t('REGISTER_ADOPTION.FORM.NEXT_BUTTON');
+
   return (
     <Box marginTop="auto" display="flex" flexDirection="row" justifyContent="space-between">
-      <Button color={theme.colors.primary[600]} variant="outline" onPress={onBackPress}>
+      <Button
+        color={theme.colors.primary[600]}
+        variant="outline"
+        onPress={onBackPress}
+        disabled={saving}
+      >
         {t('REGISTER_ADOPTION.FORM.BACK_BUTTON')}
       </Button>
       <Button
@@ -45,10 +53,10 @@ const StepperController = ({
         onPress={onNextPress}
         marginLeft="auto"
         disabled={saving}
+        isLoading={saving}
+        isLoadingText={label}
       >
-        {isLastStep
-          ? t('REGISTER_ADOPTION.FORM.CONFIRM_BUTTON')
-          : t('REGISTER_ADOPTION.FORM.NEXT_BUTTON')}
+        {label}
       </Button>
     </Box>
   );

--- a/apps/mobile/src/i18n/locales/pt-BR.json
+++ b/apps/mobile/src/i18n/locales/pt-BR.json
@@ -16,7 +16,13 @@
         "CAT": "Gato",
         "OTHER": "Outro"
       },
-      "AGE": "Idade do Pet",
+      "AGE_OPTIONS": {
+        "LABEL": "Idade do Pet",
+        "PUPPY": "Filhote (menos de 1 ano)",
+        "YOUNG": "Jovem (1-3 anos)",
+        "ADULT": "Adulto (3-8 anos)",
+        "SENIOR": "Idoso (mais de 8 anos)"
+      },
       "GENDER": {
         "LABEL": "Sexo do Pet",
         "MALE": "Macho",

--- a/apps/mobile/src/screens/register-adoption/register-adoption.screen.tsx
+++ b/apps/mobile/src/screens/register-adoption/register-adoption.screen.tsx
@@ -1,13 +1,16 @@
 import { View } from 'native-base';
 
 import RegisterAdoptionForm from '../../components/register-adoption-form/adoption-form.component';
+import SafeArea from '../../components/safe-area';
 import AppStatusBar from '../../components/status-bar/status-bar.component';
 
 const RegisterAdoption = () => {
   return (
-    <View _web={{ height: 'full' }}>
-      <AppStatusBar />
-      <RegisterAdoptionForm />
+    <View height="full">
+      <SafeArea>
+        <AppStatusBar />
+        <RegisterAdoptionForm />
+      </SafeArea>
     </View>
   );
 };

--- a/shared/models/adoption.ts
+++ b/shared/models/adoption.ts
@@ -1,6 +1,7 @@
 export type AnimalGendersType = "male" | "female";
 export type AnimalType = "dog" | "cat" | "other";
 export type AnimalSizesType = "small" | "medium" | "big";
+export type AnimalAgesType = "puppy" | "young" | "adult" | "senior";
 
 export type AdoptionType = {
   id?: string;
@@ -8,7 +9,7 @@ export type AdoptionType = {
   gender: AnimalGendersType;
   breed: string;
   type: AnimalType;
-  age: number;
+  age: AnimalAgesType;
   size: AnimalSizesType;
   observations: string;
   photos: string[];

--- a/shared/validation-schemas/src/adoption.ts
+++ b/shared/validation-schemas/src/adoption.ts
@@ -13,7 +13,7 @@ export const adoptionValidationSchema = Joi.object({
 
   type: Joi.string().max(5),
 
-  age: Joi.number(),
+  age: Joi.string().max(6),
 
   size: Joi.string().max(6),
 


### PR DESCRIPTION
closes #155

### Changes
- Make actions/controller buttons follow the keyboard as it opens
- Add error state to the text fields
- Replace the number range with a list of 4 age options 
- Add loading state to the submit button while it's saving

### Screenshots

<p>

<img src="https://github.com/animavita/animavita/assets/19699724/92572446-c4be-429d-bba5-98ea09659573" width="250" />

<img src="https://github.com/animavita/animavita/assets/19699724/02ceb196-b8a0-4c7a-b221-c244ca72152c" width="250" />

<img src="https://github.com/animavita/animavita/assets/19699724/9bff0ad5-10f7-4a61-a71d-0f37773bd5dc" width="250" />

<img src="https://github.com/animavita/animavita/assets/19699724/93a24965-668e-4af4-9924-343072b27c99" width="250" />

</p>
