### PR TITLE
Fix local development with Expo GO

### DIFF
--- a/.github/workflows/create-app-preview.yml
+++ b/.github/workflows/create-app-preview.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: 🚀 Publish preview
         uses: expo/expo-github-action/preview@v8
+        env: 
+          EXPO_PROJECT_ID: e24785ad-4327-4470-b374-7b208a31de15
         with:
           working-directory: apps/mobile
           command: eas update --auto

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -22,7 +22,7 @@ module.exports = ({ config }) => {
     extra: {
       apiUrl: getApiUrl(),
       eas: {
-        projectId: 'e24785ad-4327-4470-b374-7b208a31de15',
+        projectId: process.env.EXPO_PROJECT_ID,
       },
     },
     updates: {


### PR DESCRIPTION
### Overview
I'm not 100% sure why, but after upgrading expo SDK to v49 https://github.com/animavita/animavita/pull/205, our contributors started facing the following error:
<img width="1135" alt="Screenshot 2023-10-13 at 17 14 24" src="https://github.com/animavita/animavita/assets/19699724/4b91e666-ce03-458c-b000-e57381be4d04">

It's related to EAS and seems like if you're logged into an account that doesn't own the `projectId` on `app.config.js`, then you can not run the app through Expo Go. We only use `projectId` to generate QR Codes in maintainers' pull requests. Therefore, my workaround for now is to set it up as an env var, which means we will have this unset in local development.

https://github.com/expo/eas-cli/issues/1324