### PR TITLE
Fix nodejs version in backend/Dockerfile

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 AS base
+FROM node:18 AS base
 RUN npm i -g pnpm
 
 FROM base AS dependencies


### PR DESCRIPTION
fix(docker): nodejs version update 16v to 18v.

pnpm@9v in the latest version require node@18v as necessary dependency. https://pnpm.io/installation#compatibility