### PR TITLE
optimize dockerfile and simplify development steps 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,7 +11,7 @@ docker-compose
 LICENSE.md
 
 # Directories
-node_modules
+**/node_modules
 test
 dist
 .github

--- a/.github/actions/setup-monorepo-for-backend/action.yml
+++ b/.github/actions/setup-monorepo-for-backend/action.yml
@@ -8,7 +8,7 @@ inputs:
 
   pnpm-version:
     description: Version of pnpm to use
-    default: 7.x
+    default: 9.15.9
 
   eas-version:
     description: Version of EAS CLI to use
@@ -35,10 +35,6 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
-
-    - name: 📦 Replace .npmrc
-      run: rm .npmrc && mv .npmrc-default-node-linker .npmrc
-      shell: bash
 
     - name: 📦 Install dependencies
       run: pnpm install

--- a/.github/actions/setup-monorepo/action.yml
+++ b/.github/actions/setup-monorepo/action.yml
@@ -8,7 +8,7 @@ inputs:
 
   pnpm-version:
     description: Version of pnpm to use
-    default: 9.x
+    default: 9.15.9
 
   eas-version:
     description: Version of EAS CLI to use

--- a/.npmrc-default-node-linker
+++ b/.npmrc-default-node-linker
@@ -1,1 +1,0 @@
-auto-install-peers=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,12 +28,6 @@ Install dependencies:
 $ pnpm install
 ```
 
-In order to reflect the changes made in the shared packages to the mobile app, you must run:
-
-```sh
-$ pnpm shared:watch
-```
-
 [Click here if you want to work only on the mobile app](#developing-with-staging-backend)
 
 ### Running the infra & backend with docker
@@ -44,7 +38,14 @@ We have a `docker-compose` file that sets up a mongodb database and the backend 
 $ docker-compose up -d
 ```
 
-We're caching the `node_modules` folder to leverage cross-platform compatibility. So the first time the container is up, an anonymous volume gets created for the dependencies. With that said, whenever you change the shared packages or install a new dependency, you must rebuild the docker image telling docker to **NOT** use the existing volume from the previous container:
+### 📦 Dependency Caching Strategy
+
+We're using an anonymous volume for node_modules to ensure consistent, cross-platform dependency management. This means the container handles installing and storing node_modules, rather than relying on your local system.
+When the container starts for the first time, Docker creates an anonymous volume for /app/node_modules. This allows the container to manage dependencies internally, without interference from the host file system.
+
+> [!WARNING]  
+> Rebuilding After Dependency Changes
+> Whenever you add, remove, or update dependencies (e.g. using pnpm add), you'll need to rebuild the container and discard the old volume, so that dependencies can be reinstalled cleanly:
 
 ```sh
 $ docker-compose up --build --force-recreate -V

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@
 - Linux based distro or MacOS (we don't recommend Windows due to compatibility issues)
 - _Node:_ `20.13.1` or higher.
 - _Npm:_ `10.5.2` or higher.
-- _Pnpm:_ `9.1.1` or higher
+- _Pnpm:_ `9.15.9`
 
 ### Getting started
 > The `master` and `next` are stale branches, please do not use them.

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,13 +1,9 @@
 FROM node:20.13.1 AS base
-RUN npm i -g pnpm@9.1.1
+RUN npm i -g pnpm@9.15.9
 
 FROM base AS dependencies
 WORKDIR /app
 COPY . .
-# workaround 
-# https://github.com/animavita/animavita/pull/134
-RUN rm .npmrc
-RUN mv .npmrc-default-node-linker .npmrc
 RUN pnpm install
 
 FROM dependencies as build

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -6,11 +6,9 @@ WORKDIR /app
 COPY . .
 RUN pnpm install
 
-FROM dependencies as build
-RUN pnpm -r build
-
-FROM build as pruned
+FROM dependencies as pruned
 WORKDIR /app
+RUN pnpm --filter backend build
 RUN pnpm --filter backend deploy pruned
 
 FROM base as development

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -3,8 +3,10 @@ RUN npm i -g pnpm@9.15.9
 
 FROM base AS dependencies
 WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/backend/package.json ./apps/backend/
+RUN pnpm install --frozen-lockfile
 COPY . .
-RUN pnpm install
 
 FROM dependencies as pruned
 WORKDIR /app

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@animavita/types": "workspace:*",
-    "@animavita/validation-schemas": "workspace:*",
     "@nestjs/common": "^9.0.0",
     "@nestjs/config": "^2.2.0",
     "@nestjs/core": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "backend": "pnpm --filter backend",
-    "mobile": "pnpm --filter mobile",
-    "validation:build": "pnpm --filter validation-schemas run build",
-    "shared:watch": "nx watch --projects=@animavita/validation-schemas -- pnpm run validation:build",
-    "shared:setup": "pnpm --filter \"./shared/**\" run build",
-    "postinstall": "pnpm shared:setup"
+    "mobile": "pnpm --filter mobile"
   },
   "keywords": [],
   "author": "Gabriel Belgamo",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@animavita/types':
         specifier: workspace:*
         version: link:../../shared/types
-      '@animavita/validation-schemas':
-        specifier: workspace:*
-        version: link:../../shared/validation-schemas
       '@nestjs/common':
         specifier: ^9.0.0
         version: 9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7)
@@ -37,7 +34,7 @@ importers:
         version: 1.2.0(@nestjs/common@9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7))(class-transformer@0.5.1)(reflect-metadata@0.1.13)
       '@nestjs/mongoose':
         specifier: ^9.2.0
-        version: 9.2.0(@nestjs/common@9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7))(@nestjs/core@9.1.6(@nestjs/common@9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7))(@nestjs/platform-express@9.1.6)(reflect-metadata@0.1.13)(rxjs@7.5.7))(mongoose@6.11.4)(reflect-metadata@0.1.13)(rxjs@7.5.7)
+        version: 9.2.0(@nestjs/common@9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7))(@nestjs/core@9.1.6)(mongoose@6.11.4)(reflect-metadata@0.1.13)(rxjs@7.5.7)
       '@nestjs/passport':
         specifier: ^9.0.0
         version: 9.0.0(@nestjs/common@9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7))(passport@0.6.0)
@@ -83,7 +80,7 @@ importers:
         version: 9.0.3(chokidar@3.5.3)(typescript@4.8.4)
       '@nestjs/testing':
         specifier: ^9.0.0
-        version: 9.1.6(@nestjs/common@9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7))(@nestjs/core@9.1.6(@nestjs/common@9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7))(@nestjs/platform-express@9.1.6)(reflect-metadata@0.1.13)(rxjs@7.5.7))(@nestjs/platform-express@9.1.6(@nestjs/common@9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7))(@nestjs/core@9.1.6))
+        version: 9.1.6(@nestjs/common@9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7))(@nestjs/core@9.1.6)(@nestjs/platform-express@9.1.6)
       '@types/express':
         specifier: ^4.17.13
         version: 4.17.14
@@ -1673,6 +1670,7 @@ packages:
   '@faker-js/faker@8.1.0':
     resolution: {integrity: sha512-38DT60rumHfBYynif3lmtxMqMqmsOQIxQgEuPZxCk2yUYN0eqWpTACgxi0VpidvsJB8CRxCpvP7B3anK85FjtQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0, npm: '>=6.14.13'}
+    deprecated: Please update to a newer version
 
   '@formatjs/ecma402-abstract@1.14.3':
     resolution: {integrity: sha512-SlsbRC/RX+/zg4AApWIFNDdkLtFbkq3LNoZWXZCE/nHVKqoIJyaoQyge/I0Y38vLxowUn9KTtXgusLD91+orbg==}
@@ -6155,6 +6153,7 @@ packages:
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.has@4.5.2:
     resolution: {integrity: sha512-rnYUdIo6xRCJnQmbVFEwcxF144erlD+M3YcJUVesflU9paQaE8p+fJDcIQrlMYbxoANFL+AB9hZrzSBBk5PL+g==}
@@ -6170,6 +6169,7 @@ packages:
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
@@ -6197,6 +6197,7 @@ packages:
 
   lodash.omit@4.5.0:
     resolution: {integrity: sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==}
+    deprecated: This package is deprecated. Use destructuring assignment syntax instead.
 
   lodash.omitby@4.6.0:
     resolution: {integrity: sha512-5OrRcIVR75M288p4nbI2WLAf3ndw2GD9fyNv3Bc15+WCxJDdZ4lYndSxGd7hnG6PVjiJTeJE2dHEGhIuKGicIQ==}
@@ -6206,6 +6207,7 @@ packages:
 
   lodash.pick@4.4.0:
     resolution: {integrity: sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==}
+    deprecated: This package is deprecated. Use destructuring assignment syntax instead.
 
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
@@ -11747,7 +11749,7 @@ snapshots:
     optionalDependencies:
       class-transformer: 0.5.1
 
-  '@nestjs/mongoose@9.2.0(@nestjs/common@9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7))(@nestjs/core@9.1.6(@nestjs/common@9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7))(@nestjs/platform-express@9.1.6)(reflect-metadata@0.1.13)(rxjs@7.5.7))(mongoose@6.11.4)(reflect-metadata@0.1.13)(rxjs@7.5.7)':
+  '@nestjs/mongoose@9.2.0(@nestjs/common@9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7))(@nestjs/core@9.1.6)(mongoose@6.11.4)(reflect-metadata@0.1.13)(rxjs@7.5.7)':
     dependencies:
       '@nestjs/common': 9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7)
       '@nestjs/core': 9.1.6(@nestjs/common@9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7))(@nestjs/platform-express@9.1.6)(reflect-metadata@0.1.13)(rxjs@7.5.7)
@@ -11794,7 +11796,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/testing@9.1.6(@nestjs/common@9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7))(@nestjs/core@9.1.6(@nestjs/common@9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7))(@nestjs/platform-express@9.1.6)(reflect-metadata@0.1.13)(rxjs@7.5.7))(@nestjs/platform-express@9.1.6(@nestjs/common@9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7))(@nestjs/core@9.1.6))':
+  '@nestjs/testing@9.1.6(@nestjs/common@9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7))(@nestjs/core@9.1.6)(@nestjs/platform-express@9.1.6)':
     dependencies:
       '@nestjs/common': 9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7)
       '@nestjs/core': 9.1.6(@nestjs/common@9.1.6(class-transformer@0.5.1)(reflect-metadata@0.1.13)(rxjs@7.5.7))(@nestjs/platform-express@9.1.6)(reflect-metadata@0.1.13)(rxjs@7.5.7)

--- a/shared/validation-schemas/package.json
+++ b/shared/validation-schemas/package.json
@@ -3,10 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "description": "",
-  "main": "dist/src/index.js",
-  "scripts": {
-    "build": "tsc"
-  },
+  "main": "src/index.ts",
   "keywords": [],
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
- Reverts the work done to workaround the hoist issue from https://github.com/animavita/animavita/pull/134 by bumping pnpm to v9.15.9
- Disables build steps for shared packages as they don't need to be distributed
- Caches `node_modules` across docker builds